### PR TITLE
fix: aws-cli インストールをpip経由に変更

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -107,7 +107,10 @@ steps:
         if [ "${DRONE_BUILD_EVENT}" = "push" ] && [ "${DRONE_BRANCH}" = "main" ]; then
           echo ""
           echo "🔐 Logging in to ECR..."
-          apk add --no-cache aws-cli
+          # Alpineのaws-cliパッケージはlibexpat ABI mismatchで壊れているため
+          # pip経由でインストールする
+          apk add --no-cache python3 py3-pip
+          pip3 install --break-system-packages awscli
           aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $ECR_REGISTRY
 
           echo "🏷️ Tagging image for ECR..."


### PR DESCRIPTION
## Summary
Alpine の aws-cli パッケージが libexpat ABI mismatch で壊れており、ECRログインが失敗する問題を修正。

## エラー
\`\`\`
Error relocating /usr/lib/python3.12/lib-dynload/pyexpat.cpython-312-x86_64-linux-musl.so:
  XML_SetAllocTrackerActivationThreshold: symbol not found
Error: Cannot perform an interactive login from a non TTY device
\`\`\`

## 修正
\`apk add --no-cache aws-cli\` → \`pip3 install --break-system-packages awscli\`

## Test plan
- [ ] CIパス
- [ ] ECRログイン成功
- [ ] イメージpush成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)