### PR TITLE
docs: READMEをポートフォリオ向けに整備

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,112 +1,198 @@
-# MyBlog Frontend
+# My Blog — Frontend
 
-React + TypeScript + Vite を使用したブログフロントエンドアプリケーション
+個人ブログプラットフォームのフロントエンドアプリケーション。
+React + TypeScript で構築し、Atomic Design によるコンポーネント設計、JWT 認証、リッチテキストエディタなどを実装しています。
 
-## 🚀 クイックスタート
+<!-- TODO: サイトのスクリーンショットを貼る -->
+<!-- ![トップページ](docs/screenshots/top.png) -->
+
+## 技術スタック
+
+| カテゴリ | 技術 |
+|---|---|
+| フレームワーク | React 19 + TypeScript 5.8 |
+| ビルドツール | Vite 6 |
+| ルーティング | React Router v7 |
+| スタイリング | Tailwind CSS 3 |
+| リッチテキスト | TipTap（Headless Editor） |
+| テスト | Vitest + Testing Library |
+| モック | MSW（Mock Service Worker） |
+| リンター | ESLint 9（Flat Config） |
+| コンテナ | Docker（multi-stage build） |
+| CI/CD | Drone CI → AWS ECR |
+| 本番サーバー | Nginx（Alpine） |
+
+## アーキテクチャ
+
+### コンポーネント設計（Atomic Design）
+
+```
+src/components/
+├── atoms/        # Button, Input, Textarea, Skeleton, LoadingSpinner
+├── molecules/    # CommentItem, CommentButtons, ThemeToggle
+├── organisms/    # CommentForm, RichTextEditor, Header, CommentList
+├── layouts/      # Layout, Container
+└── utils/        # ErrorBoundary, sanitizer, cn utility
+```
+
+再利用性と責務分離を意識し、atoms → molecules → organisms の粒度でコンポーネントを分割しています。
+
+### ディレクトリ構成
+
+```
+app/src/
+├── api/          # API クライアント（認証・バリデーション付き）
+├── components/   # Atomic Design ベースのコンポーネント群
+├── context/      # AuthContext, ThemeContext（グローバル状態）
+├── hooks/        # カスタムフック（useAuth, usePosts など）
+├── pages/        # ページコンポーネント（Top, PostDetail, Admin など）
+├── router/       # ルーティング定義（認証ガード付き）
+├── types/        # TypeScript 型定義
+├── constants/    # 設定値
+├── mocks/        # MSW ハンドラー（開発・テスト用）
+└── test/         # テスト設定・ユーティリティ
+```
+
+### 状態管理
+
+外部ライブラリ（Redux 等）は使用せず、**React Context API** で必要十分な状態管理を実現しています。
+
+- **AuthContext** — JWT トークン管理、ログイン/ログアウト
+- **ThemeContext** — ライト/ダークモード切替（システム設定に追従）
+
+### API クライアント設計
+
+`src/api/client.ts` にて、認証付き API クライアントを独自実装しています。
+
+- Authorization ヘッダーの自動付与（安全なオリジン・パスのみ）
+- エンドポイントのバリデーション（プロトコル相対URL、パストラバーサルを拒否）
+- レスポンスの型付きパース
+- エラーメッセージのサニタイズ（最大500文字）
+
+## 主要機能
+
+### ブログ閲覧
+- 記事一覧表示（カテゴリ別フィルタ対応）
+- 記事詳細ページ（リッチテキスト表示）
+- コメント機能（認証ユーザーのみ）
+
+<!-- TODO: 記事一覧のスクリーンショット -->
+<!-- ![記事一覧](docs/screenshots/posts.png) -->
+
+### 管理画面
+- 記事の作成・編集・削除
+- TipTap ベースのリッチテキストエディタ（画像・リンク対応）
+- 画像アップロード（Rails ActiveStorage 連携）
+- Movable Type 形式からのインポート機能
+
+<!-- TODO: 管理画面のスクリーンショット -->
+<!-- ![管理画面](docs/screenshots/admin.png) -->
+
+### ダークモード
+- ライト/ダーク切替（ボタン + システム設定の自動検知）
+- Tailwind CSS の `class` ベースで実装
+
+<!-- TODO: ダークモードのスクリーンショット -->
+<!-- ![ダークモード](docs/screenshots/dark-mode.png) -->
+
+## セキュリティ
+
+| 対策 | 実装 |
+|---|---|
+| XSS 防止 | DOMPurify によるHTML サニタイズ |
+| 認証 | JWT（Authorization ヘッダー） |
+| トークン送信先制限 | 設定済み API ベース URL のみに送信 |
+| エンドポイント検証 | プロトコル相対URL・パストラバーサルを拒否 |
+| セキュリティヘッダー | X-Frame-Options, X-Content-Type-Options, CSP 等（Nginx） |
+| エラー情報の制限 | エラーメッセージを最大500文字に切り詰め |
+
+## テスト
 
 ```bash
-# インストール
+# テスト実行
+npm run test
+
+# UI付きテスト
+npm run test:ui
+
+# カバレッジ計測
+npm run test:coverage
+```
+
+- **Vitest** + **Testing Library** によるコンポーネントテスト
+- **MSW** で API レスポンスをモック（テスト時はネットワーク通信なし）
+
+## デプロイ
+
+### Docker（マルチステージビルド）
+
+```dockerfile
+# ステージ1: Node.js でビルド
+# ステージ2: Nginx Alpine で配信（軽量）
+```
+
+本番イメージは **Nginx Alpine ベース** で、ビルド成果物（静的ファイル）のみを含みます。
+
+### CI/CD（Drone）
+
+```
+push to main
+  → Docker ビルド
+  → コンテナ起動検証（ヘルスチェック）
+  → ECR push（commit SHA + latest タグ）
+  → K8s 上で自動デプロイ（Keel による image digest 検知）
+```
+
+### Nginx 設定
+
+- SPA ルーティング（`try_files $uri $uri/ /index.html`）
+- `/api/*` はフロントエンドで処理せず 404 を返す（バックエンドへの誤ルーティング防止）
+- 静的アセット: 1年キャッシュ（immutable）
+- `index.html`: キャッシュなし（常に最新を配信）
+- Gzip 圧縮有効
+
+## 開発環境セットアップ
+
+### 前提条件
+
+- Node.js 20+
+- npm
+
+### モックモードで起動（バックエンド不要）
+
+```bash
+cd app
 npm install
-
-# 開発サーバー起動（モックデータ）
 npm run dev:mock
+```
 
-# または実 API を使用
+MSW がブラウザ上で API レスポンスをモックするため、バックエンドなしで画面の動作確認ができます。
+
+### 実 API モードで起動
+
+```bash
+cd app
 npm run dev:api
 ```
 
-## 🔐 Bitwarden 環境変数管理
+バックエンド（`http://localhost:3000`）が起動している必要があります。
+Vite の dev proxy が `/api` リクエストをバックエンドに転送します。
 
-### セットアップ方法
-
-#### 方法A: セッションベース（開発環境向け）
-
-```bash
-# 1. Bitwarden CLI をインストール
-brew install bitwarden-cli
-
-# 2. Bitwarden にログイン
-bw login
-
-# 3. セッションを取得
-export BW_SESSION=$(bw unlock --raw)
-
-# 4. 開発サーバー起動
-npm run dev:mock
-```
-
-#### 方法B: API Key ベース（本番環境・CI/CD向け）
-
-永続的な認証が必要な場合は、API Key を使用します。
+### Docker Compose で起動
 
 ```bash
-# 1. Bitwarden Web Vault から API Key を取得
-#    Settings > Security > Keys > Client ID と Client Secret をコピー
-
-# 2. 環境変数を設定
-export BW_CLIENT_ID="your-client-id"
-export BW_CLIENT_SECRET="your-client-secret"
-export BW_PASSWORD="your-master-password"
-
-# 3. docker-compose で起動
 docker-compose up -d
 ```
 
-### Drone CI/CD での設定
+### 環境変数
 
-**1. Drone Secrets に登録**
+| 変数 | 説明 | デフォルト |
+|---|---|---|
+| `VITE_ENABLE_MSW` | MSW モック有効化 | `false` |
+| `VITE_API_BASE_URL` | API ベース URL | `/api` |
 
-Drone Web UI で以下の Secret を登録します：
-- `bw_client_id`: Bitwarden API Client ID
-- `bw_client_secret`: Bitwarden API Client Secret
-- `bw_password`: Bitwarden Master Password
+環境変数は Bitwarden CLI 経由で安全に管理しています。詳細は `app/scripts/load-env-from-bitwarden.sh` を参照してください。
 
-**2. `.drone.yml` の設定**
+## 関連リポジトリ
 
-```yaml
-steps:
-  - name: deploy
-    image: docker/compose:latest
-    environment:
-      # ホスト側の環境変数名（docker-compose.yml で参照）
-      BW_CLIENT_ID:
-        from_secret: bw_client_id
-      BW_CLIENT_SECRET:
-        from_secret: bw_client_secret
-      BW_PASSWORD:
-        from_secret: bw_password
-    commands:
-      - docker-compose up -d
-```
-
-**環境変数のマッピング:**
-- `BW_CLIENT_ID` (Drone Secret) → `BW_CLIENTID` (コンテナ内)
-- `BW_CLIENT_SECRET` (Drone Secret) → `BW_CLIENTSECRET` (コンテナ内)
-- `BW_PASSWORD` (Drone Secret) → `BW_PASSWORD` (コンテナ内)
-
-### 保存されている環境設定
-
-Bitwarden に以下の環境設定が保存されています：
-
-- **myblog-frontend-env-api**: 実 API モード（`VITE_ENABLE_MSW=false`）
-- **myblog-frontend-env-mock**: モックモード（`VITE_ENABLE_MSW=true`）
-
-### 環境変数の確認
-
-```bash
-# API モードの設定を確認
-bw get notes myblog-frontend-env-api
-
-# モックモードの設定を確認
-bw get notes myblog-frontend-env-mock
-```
-
-## 📦 ビルド
-
-```bash
-npm run build
-```
-
-## 📚 詳細なドキュメント
-
-詳細なセットアップ手順は [`app/README.md`](./app/README.md) を参照してください。
+- [myblog-backend](https://github.com/terumitt-dev/myblog-backend) — Rails API バックエンド


### PR DESCRIPTION
## Summary
- READMEをポートフォリオ向けに全面書き直し
- 技術スタック、Atomic Design設計、セキュリティ対策、デプロイフローを体系的に記載
- スクリーンショットは TODO コメントで4箇所に配置（後日差し替え）
- Bitwarden の詳細手順は簡素化

🤖 Generated with [Claude Code](https://claude.com/claude-code)