### PR TITLE
fix: ヘッダーの「My Blog」表示を削除、タイトルを変更

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="ja">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />

--- a/app/index.html
+++ b/app/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>My Blog (go-lilaregard)</title>
   </head>
   <body>
     <div id="root"></div>

--- a/app/src/components/organisms/Header.tsx
+++ b/app/src/components/organisms/Header.tsx
@@ -7,7 +7,6 @@ const Header = () => {
       className="flex justify-between items-center px-4 py-2"
       aria-label="サイトヘッダー"
     >
-      <h1 className="text-xl font-bold">My Blog</h1>
       <ThemeToggle />
     </header>
   );

--- a/app/src/components/organisms/Header.tsx
+++ b/app/src/components/organisms/Header.tsx
@@ -4,7 +4,7 @@ import ThemeToggle from "@/components/molecules/ThemeToggle";
 const Header = () => {
   return (
     <header
-      className="flex justify-between items-center px-4 py-2"
+      className="flex justify-end items-center px-4 py-2"
       aria-label="サイトヘッダー"
     >
       <ThemeToggle />

--- a/app/src/pages/Category.tsx
+++ b/app/src/pages/Category.tsx
@@ -318,7 +318,6 @@ const Category = () => {
     return (
       <div className="min-h-screen bg-gray-100 dark:bg-gray-900 flex items-center justify-center">
         <header className="absolute top-0 left-0 right-0 flex justify-between items-center px-4 py-2 z-10">
-          <h1 className="text-lg sm:text-xl lg:text-2xl font-bold">My Blog</h1>
           <ThemeToggle />
         </header>
         <div className="text-center">
@@ -341,9 +340,6 @@ const Category = () => {
     >
       {/* Header */}
       <header className="flex justify-between items-center px-4 py-2 relative z-20">
-        <h1 className="text-lg sm:text-xl lg:text-2xl font-bold text-gray-800 dark:text-gray-200">
-          My Blog
-        </h1>
         <ThemeToggle />
       </header>
 

--- a/app/src/pages/Category.tsx
+++ b/app/src/pages/Category.tsx
@@ -317,7 +317,7 @@ const Category = () => {
   if (!category || !categoryConfig || !isValidCategory) {
     return (
       <div className="min-h-screen bg-gray-100 dark:bg-gray-900 flex items-center justify-center">
-        <header className="absolute top-0 left-0 right-0 flex justify-between items-center px-4 py-2 z-10">
+        <header className="absolute top-0 left-0 right-0 flex justify-end items-center px-4 py-2 z-10">
           <ThemeToggle />
         </header>
         <div className="text-center">
@@ -339,7 +339,7 @@ const Category = () => {
       style={{ backgroundColor: categoryConfig.backgroundColor }}
     >
       {/* Header */}
-      <header className="flex justify-between items-center px-4 py-2 relative z-20">
+      <header className="flex justify-end items-center px-4 py-2 relative z-20">
         <ThemeToggle />
       </header>
 

--- a/app/src/pages/Top.tsx
+++ b/app/src/pages/Top.tsx
@@ -79,11 +79,6 @@ const Top = () => {
   return (
     <Layout>
       <Container size="wide" padding="section" className="space-y-8">
-        {/* メインタイトル（スクリーンリーダー用） */}
-        <h1 id="page-title" className="sr-only">
-          My Blog - ホームページ
-        </h1>
-
         {/* ヒーロー画像 */}
         <section aria-label="ブログのメインビジュアル">
           <div className="w-full overflow-hidden rounded-xl">


### PR DESCRIPTION
## Summary
- ヘッダーから「My Blog」テキストを削除（Header.tsx, Category.tsx）
- ブラウザタブのタイトルを「Vite + React + TS」→「My Blog (go-lilaregard)」に変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)