### PR TITLE
feat: パスワードリセット画面を追加

### DIFF
--- a/app/src/pages/Login.tsx
+++ b/app/src/pages/Login.tsx
@@ -173,14 +173,25 @@ const Login = () => {
           </button>
         </form>
 
-        <div className="text-center">
-          <button
-            type="button"
-            onClick={() => navigate("/")}
-            className="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
-          >
-            ← ホームに戻る
-          </button>
+        <div className="text-center space-y-2">
+          <div>
+            <button
+              type="button"
+              onClick={() => navigate("/password/reset")}
+              className="text-sm text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 transition-colors"
+            >
+              パスワードをお忘れの方はこちら
+            </button>
+          </div>
+          <div>
+            <button
+              type="button"
+              onClick={() => navigate("/")}
+              className="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
+            >
+              ← ホームに戻る
+            </button>
+          </div>
         </div>
       </div>
     </Layout>

--- a/app/src/pages/Login.tsx
+++ b/app/src/pages/Login.tsx
@@ -1,7 +1,7 @@
 // app/src/pages/Login.tsx
 import Layout from "@/components/layouts/Layout";
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, Link } from "react-router-dom";
 import { useAuth } from "@/hooks/useAuth";
 import LoadingSpinner from "@/components/atoms/LoadingSpinner";
 import { cn } from "@/components/utils/cn";
@@ -14,7 +14,9 @@ const Login = () => {
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
 
-  const handleSubmit = async () => {
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
     if (!email.trim() || !password.trim()) {
       setError("メールアドレスとパスワードを入力してください。");
       return;
@@ -33,11 +35,6 @@ const Login = () => {
     } finally {
       setLoading(false);
     }
-  };
-
-  const handleLogin = (e: React.FormEvent) => {
-    e.preventDefault();
-    handleSubmit();
   };
 
   return (
@@ -62,7 +59,7 @@ const Login = () => {
           </div>
         )}
 
-        <form onSubmit={handleLogin} className="space-y-6">
+        <form onSubmit={handleSubmit} className="space-y-6">
           <div className="space-y-2">
             <label
               htmlFor="email"
@@ -175,22 +172,20 @@ const Login = () => {
 
         <div className="text-center space-y-2">
           <div>
-            <button
-              type="button"
-              onClick={() => navigate("/password/reset")}
+            <Link
+              to="/password/reset"
               className="text-sm text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 transition-colors"
             >
               パスワードをお忘れの方はこちら
-            </button>
+            </Link>
           </div>
           <div>
-            <button
-              type="button"
-              onClick={() => navigate("/")}
+            <Link
+              to="/"
               className="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
             >
               ← ホームに戻る
-            </button>
+            </Link>
           </div>
         </div>
       </div>

--- a/app/src/pages/PasswordResetConfirm.tsx
+++ b/app/src/pages/PasswordResetConfirm.tsx
@@ -12,26 +12,24 @@ const TOKEN_STORAGE_KEY = "reset_password_token";
 
 const PasswordResetConfirm = () => {
   const [searchParams] = useSearchParams();
-  // URL → sessionStorage の順でトークンを取得
-  // URL に含まれていれば sessionStorage に退避してから URL 除去するため、
-  // リロードしても sessionStorage からトークンを復元できる
-  const [token] = useState(() => {
+  const [token, setToken] = useState("");
+
+  // URL → sessionStorage の順でトークンを同期し、URL上のトークンは即座に除去する
+  // マウント中に searchParams が変化しても（同じ画面で別リンクを踏んだ場合など）、
+  // useEffect で追従してトークンを更新できる
+  useEffect(() => {
     const tokenFromUrl = searchParams.get(TOKEN_STORAGE_KEY);
     if (tokenFromUrl) {
       sessionStorage.setItem(TOKEN_STORAGE_KEY, tokenFromUrl);
-      return tokenFromUrl;
+      setToken(tokenFromUrl);
+      window.history.replaceState(
+        {},
+        document.title,
+        `${window.location.pathname}${window.location.hash}`,
+      );
+      return;
     }
-    return sessionStorage.getItem(TOKEN_STORAGE_KEY) || "";
-  });
-
-  // マウント後にURLからトークンを除去（ブラウザ履歴・Referer経由での漏洩を防止）
-  useEffect(() => {
-    if (!searchParams.get(TOKEN_STORAGE_KEY)) return;
-    window.history.replaceState(
-      {},
-      document.title,
-      `${window.location.pathname}${window.location.hash}`,
-    );
+    setToken(sessionStorage.getItem(TOKEN_STORAGE_KEY) || "");
   }, [searchParams]);
 
   const [password, setPassword] = useState("");
@@ -75,6 +73,11 @@ const PasswordResetConfirm = () => {
         const errors = Array.isArray(data.errors)
           ? data.errors.join(", ")
           : "パスワードの更新に失敗しました。リンクの有効期限切れの可能性があります。";
+        // トークン失効系のエラー時は sessionStorage からも破棄し、
+        // 再リロードでも壊れた状態から復帰できるようにする
+        if ([401, 404, 422].includes(response.status)) {
+          sessionStorage.removeItem(TOKEN_STORAGE_KEY);
+        }
         setError(errors);
         return;
       }

--- a/app/src/pages/PasswordResetConfirm.tsx
+++ b/app/src/pages/PasswordResetConfirm.tsx
@@ -12,7 +12,9 @@ const TOKEN_STORAGE_KEY = "reset_password_token";
 
 const PasswordResetConfirm = () => {
   const [searchParams] = useSearchParams();
-  const [token, setToken] = useState("");
+  // null は useEffect 実行前の「未確定」状態を表す。"" にすると初回レンダーで
+  // `if (!token)` 分岐に入って一瞬「無効トークン」画面がフラッシュするのを避けるため。
+  const [token, setToken] = useState<string | null>(null);
 
   // URL → sessionStorage の順でトークンを同期し、URL上のトークンは即座に除去する
   // マウント中に searchParams が変化しても（同じ画面で別リンクを踏んだ場合など）、
@@ -92,6 +94,11 @@ const PasswordResetConfirm = () => {
       setLoading(false);
     }
   };
+
+  // useEffect 実行前は何も描画しない（フラッシュ回避）
+  if (token === null) {
+    return null;
+  }
 
   // トークンがない場合はフォームを表示せず、早期リターン
   if (!token) {

--- a/app/src/pages/PasswordResetConfirm.tsx
+++ b/app/src/pages/PasswordResetConfirm.tsx
@@ -91,14 +91,26 @@ const PasswordResetConfirm = () => {
 
       if (!response.ok) {
         const data = await response.json().catch(() => ({}));
-        const errors = Array.isArray(data.errors)
-          ? data.errors.join(", ")
-          : "パスワードの更新に失敗しました。リンクの有効期限切れの可能性があります。";
-        // トークン失効系のエラー（401/404）時は sessionStorage からも破棄し、
-        // 再リロードでも壊れた状態から復帰できるようにする。
-        // 422 はパスワード強度などの通常バリデーション失敗にも使われるため除外し、
-        // 正しいリンクで再入力できるようにする。
-        if ([401, 404].includes(response.status)) {
+        const apiErrors = Array.isArray(data.errors) ? data.errors : [];
+        const errorMessage =
+          apiErrors.length > 0
+            ? apiErrors.join(", ")
+            : "パスワードの更新に失敗しました。リンクの有効期限切れの可能性があります。";
+
+        // トークン失効系の検知:
+        //   1. 既知の失効ステータスコード (現 backend は 401 のみ。400/404/410 は将来の
+        //      backend 変更や別ルート経由のレスポンスへの defense-in-depth として広めに見る)
+        //   2. errors 配列の文言にトークン関連キーワードが含まれる場合 (ja/en 両対応)
+        //      → 422 でも token 起因のエラーが返る backend に切り替わった場合に救う。
+        //      パスワードバリデーション失敗 (Password is too short 等) は引っかからないため
+        //      正しいトークンでの再入力フローは維持される。
+        const hasTokenError =
+          [400, 401, 404, 410].includes(response.status) ||
+          apiErrors.some((msg) =>
+            /token|トークン|期限|expired|invalid/i.test(String(msg)),
+          );
+
+        if (hasTokenError) {
           try {
             sessionStorage.removeItem(TOKEN_STORAGE_KEY);
           } catch {
@@ -106,7 +118,7 @@ const PasswordResetConfirm = () => {
           }
           setToken("");
         }
-        setError(errors);
+        setError(errorMessage);
         return;
       }
 

--- a/app/src/pages/PasswordResetConfirm.tsx
+++ b/app/src/pages/PasswordResetConfirm.tsx
@@ -10,7 +10,15 @@ import { API_BASE } from "@/api/base";
 
 const PasswordResetConfirm = () => {
   const [searchParams] = useSearchParams();
-  const token = searchParams.get("reset_password_token") || "";
+  // トークンは初回マウント時に1度だけ取得し、直後にURLから除去する
+  // （ブラウザ履歴・Referer経由での漏洩を防止）
+  const [token] = useState(() => {
+    const value = searchParams.get("reset_password_token") || "";
+    if (value) {
+      window.history.replaceState({}, document.title, window.location.pathname);
+    }
+    return value;
+  });
 
   const [password, setPassword] = useState("");
   const [passwordConfirmation, setPasswordConfirmation] = useState("");

--- a/app/src/pages/PasswordResetConfirm.tsx
+++ b/app/src/pages/PasswordResetConfirm.tsx
@@ -106,7 +106,7 @@ const PasswordResetConfirm = () => {
         //      正しいトークンでの再入力フローは維持される。
         const hasTokenError =
           [400, 401, 404, 410].includes(response.status) ||
-          apiErrors.some((msg) =>
+          apiErrors.some((msg: unknown) =>
             /token|トークン|期限|expired|invalid/i.test(String(msg)),
           );
 

--- a/app/src/pages/PasswordResetConfirm.tsx
+++ b/app/src/pages/PasswordResetConfirm.tsx
@@ -3,7 +3,7 @@
 // URLクエリ ?reset_password_token=... を受け取り、新パスワードを設定する
 import Layout from "@/components/layouts/Layout";
 import { useState } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useSearchParams, Link } from "react-router-dom";
 import LoadingSpinner from "@/components/atoms/LoadingSpinner";
 import { cn } from "@/components/utils/cn";
 import { API_BASE } from "@/api/base";
@@ -17,15 +17,9 @@ const PasswordResetConfirm = () => {
   const [error, setError] = useState("");
   const [success, setSuccess] = useState(false);
   const [loading, setLoading] = useState(false);
-  const navigate = useNavigate();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-
-    if (!token) {
-      setError("リセットトークンが無効です。メール内のリンクから再度アクセスしてください。");
-      return;
-    }
 
     if (password.length < 6) {
       setError("パスワードは6文字以上で入力してください。");
@@ -70,6 +64,38 @@ const PasswordResetConfirm = () => {
     }
   };
 
+  // トークンがない場合はフォームを表示せず、早期リターン
+  if (!token) {
+    return (
+      <Layout>
+        <div className="max-w-md mx-auto p-4 sm:p-6 lg:p-8 space-y-4">
+          <div
+            className="p-6 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg"
+            role="alert"
+          >
+            <h2 className="text-lg font-semibold text-red-800 dark:text-red-300 mb-2">
+              リセットトークンが無効です
+            </h2>
+            <p className="text-sm text-red-700 dark:text-red-400">
+              メール内のリンクから再度アクセスしてください。
+            </p>
+          </div>
+          <Link
+            to="/password/reset"
+            className={cn(
+              "block text-center py-3 px-4 border border-transparent rounded-lg shadow-sm",
+              "text-sm font-medium text-white",
+              "bg-blue-600 hover:bg-blue-700",
+              "focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500",
+            )}
+          >
+            パスワードリセットを再申請する
+          </Link>
+        </div>
+      </Layout>
+    );
+  }
+
   if (success) {
     return (
       <Layout>
@@ -82,18 +108,17 @@ const PasswordResetConfirm = () => {
               新しいパスワードでログインしてください。
             </p>
           </div>
-          <button
-            type="button"
-            onClick={() => navigate("/login")}
+          <Link
+            to="/login"
             className={cn(
-              "w-full py-3 px-4 border border-transparent rounded-lg shadow-sm",
+              "block text-center py-3 px-4 border border-transparent rounded-lg shadow-sm",
               "text-sm font-medium text-white",
               "bg-blue-600 hover:bg-blue-700",
               "focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500",
             )}
           >
             ログイン画面へ
-          </button>
+          </Link>
         </div>
       </Layout>
     );
@@ -201,6 +226,15 @@ const PasswordResetConfirm = () => {
             )}
           </button>
         </form>
+
+        <div className="text-center">
+          <Link
+            to="/login"
+            className="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
+          >
+            ← ログイン画面に戻る
+          </Link>
+        </div>
       </div>
     </Layout>
   );

--- a/app/src/pages/PasswordResetConfirm.tsx
+++ b/app/src/pages/PasswordResetConfirm.tsx
@@ -8,19 +8,31 @@ import LoadingSpinner from "@/components/atoms/LoadingSpinner";
 import { cn } from "@/components/utils/cn";
 import { API_BASE } from "@/api/base";
 
+const TOKEN_STORAGE_KEY = "reset_password_token";
+
 const PasswordResetConfirm = () => {
   const [searchParams] = useSearchParams();
-  const [token] = useState(() => searchParams.get("reset_password_token") || "");
+  // URL → sessionStorage の順でトークンを取得
+  // URL に含まれていれば sessionStorage に退避してから URL 除去するため、
+  // リロードしても sessionStorage からトークンを復元できる
+  const [token] = useState(() => {
+    const tokenFromUrl = searchParams.get(TOKEN_STORAGE_KEY);
+    if (tokenFromUrl) {
+      sessionStorage.setItem(TOKEN_STORAGE_KEY, tokenFromUrl);
+      return tokenFromUrl;
+    }
+    return sessionStorage.getItem(TOKEN_STORAGE_KEY) || "";
+  });
 
   // マウント後にURLからトークンを除去（ブラウザ履歴・Referer経由での漏洩を防止）
   useEffect(() => {
-    if (!token) return;
+    if (!searchParams.get(TOKEN_STORAGE_KEY)) return;
     window.history.replaceState(
       {},
       document.title,
       `${window.location.pathname}${window.location.hash}`,
     );
-  }, [token]);
+  }, [searchParams]);
 
   const [password, setPassword] = useState("");
   const [passwordConfirmation, setPasswordConfirmation] = useState("");
@@ -67,6 +79,8 @@ const PasswordResetConfirm = () => {
         return;
       }
 
+      // 成功後は sessionStorage のトークンを破棄（再利用防止）
+      sessionStorage.removeItem(TOKEN_STORAGE_KEY);
       setSuccess(true);
     } catch {
       setError("通信エラーが発生しました。");

--- a/app/src/pages/PasswordResetConfirm.tsx
+++ b/app/src/pages/PasswordResetConfirm.tsx
@@ -3,7 +3,7 @@
 // URLクエリ ?reset_password_token=... を受け取り、新パスワードを設定する
 import Layout from "@/components/layouts/Layout";
 import { useState, useEffect } from "react";
-import { useSearchParams, Link } from "react-router-dom";
+import { useSearchParams, useLocation, Link } from "react-router-dom";
 import LoadingSpinner from "@/components/atoms/LoadingSpinner";
 import { cn } from "@/components/utils/cn";
 import { API_BASE } from "@/api/base";
@@ -12,18 +12,20 @@ const TOKEN_STORAGE_KEY = "reset_password_token";
 
 const PasswordResetConfirm = () => {
   const [searchParams] = useSearchParams();
+  // hash 変更にも追従するため React Router の location を依存に含める。
+  // window.location.hash 直読みだと React に変更通知されず再 sync しないケースがある。
+  const location = useLocation();
   // null は useEffect 実行前の「未確定」状態を表す。"" にすると初回レンダーで
   // `if (!token)` 分岐に入って一瞬「無効トークン」画面がフラッシュするのを避けるため。
   const [token, setToken] = useState<string | null>(null);
 
   // URL → sessionStorage の順でトークンを同期し、URL上のトークンは即座に除去する
-  // マウント中に searchParams が変化しても（同じ画面で別リンクを踏んだ場合など）、
-  // useEffect で追従してトークンを更新できる
+  // マウント中に searchParams または hash が変化したときも追従する
   useEffect(() => {
     // backend のメールリンクはフラグメント (#reset_password_token=...) ベース。
     // クエリ文字列 (?reset_password_token=...) も後方互換のためフォールバック。
     // フラグメントを優先することで、サーバログ・Referer 経由の漏えいを最小化。
-    const hashParams = new URLSearchParams(window.location.hash.slice(1));
+    const hashParams = new URLSearchParams(location.hash.slice(1));
     const tokenFromHash = hashParams.get(TOKEN_STORAGE_KEY);
     const tokenFromQuery = searchParams.get(TOKEN_STORAGE_KEY);
     const tokenFromUrl = tokenFromHash || tokenFromQuery;
@@ -52,7 +54,7 @@ const PasswordResetConfirm = () => {
     } catch {
       setToken("");
     }
-  }, [searchParams]);
+  }, [searchParams, location.hash]);
 
   const [password, setPassword] = useState("");
   const [passwordConfirmation, setPasswordConfirmation] = useState("");
@@ -108,15 +110,22 @@ const PasswordResetConfirm = () => {
         // トークン失効系の検知:
         //   1. 既知の失効ステータスコード (現 backend は 401 のみ。400/404/410 は将来の
         //      backend 変更や別ルート経由のレスポンスへの defense-in-depth として広めに見る)
-        //   2. errors 配列の文言にトークン関連キーワードが含まれる場合 (ja/en 両対応)
-        //      → 422 でも token 起因のエラーが返る backend に切り替わった場合に救う。
-        //      パスワードバリデーション失敗 (Password is too short 等) は引っかからないため
-        //      正しいトークンでの再入力フローは維持される。
+        //   2. errors 配列の文言が明確に reset_password_token に紐づく場合のみ
+        //      → 「Password confirmation is invalid」のような通常のバリデーション失敗で
+        //         誤って token を破棄しないよう、文言マッチは reset_password_token 関連に限定。
         const hasTokenError =
           [400, 401, 404, 410].includes(response.status) ||
-          apiErrors.some((msg: unknown) =>
-            /token|トークン|期限|expired|invalid/i.test(String(msg)),
-          );
+          apiErrors.some((msg: unknown) => {
+            const normalized = String(msg).toLowerCase();
+            return (
+              normalized.includes("reset_password_token") ||
+              normalized.includes("reset password token") ||
+              normalized.includes("expired token") ||
+              normalized.includes("リセットパスワードトークン") ||
+              normalized.includes("リセット用トークン") ||
+              normalized.includes("期限切れ")
+            );
+          });
 
         if (hasTokenError) {
           try {

--- a/app/src/pages/PasswordResetConfirm.tsx
+++ b/app/src/pages/PasswordResetConfirm.tsx
@@ -39,8 +39,11 @@ const PasswordResetConfirm = () => {
         // クエリ・フラグメント両方を URL から除去する。
         // 第1引数は React Router の location.state を巻き込まないように
         // 既存の history.state を保持する（{} に置換すると遷移情報が失われる）。
+        // 同時に resetPasswordTokenLoaded フラグを history.state に記録することで、
+        // 「URL を浄化した直後の遷移」だけ sessionStorage の token 再利用を許可する
+        // （URL に token が無い別訪問で古い token を誤って拾うのを防ぐ）。
         window.history.replaceState(
-          window.history.state,
+          { ...(window.history.state ?? {}), resetPasswordTokenLoaded: true },
           document.title,
           window.location.pathname,
         );
@@ -49,8 +52,20 @@ const PasswordResetConfirm = () => {
       }
       return;
     }
+    // URL に token が無いときの sessionStorage 再利用は、直前に URL から
+    // 取り込んで replaceState した場合 (resetPasswordTokenLoaded フラグ) に限定する。
+    // それ以外では古い token の誤用を防ぐため明示的に破棄する。
     try {
-      setToken(sessionStorage.getItem(TOKEN_STORAGE_KEY) || "");
+      const canReuseStoredToken =
+        window.history.state?.resetPasswordTokenLoaded === true;
+      if (!canReuseStoredToken) {
+        sessionStorage.removeItem(TOKEN_STORAGE_KEY);
+      }
+      setToken(
+        canReuseStoredToken
+          ? sessionStorage.getItem(TOKEN_STORAGE_KEY) || ""
+          : "",
+      );
     } catch {
       setToken("");
     }
@@ -62,13 +77,15 @@ const PasswordResetConfirm = () => {
   const [success, setSuccess] = useState(false);
   const [loading, setLoading] = useState(false);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    // setLoading が反映される前に連続クリックされると、同じワンタイムトークンで
-    // PATCH が複数回飛んで失効レースが起こる。ボタン disabled に加えて
-    // ハンドラ先頭でも明示的に多重送信をブロック。
-    if (loading) {
+    // setLoading の反映前に連続クリックされた場合の多重送信は React state では
+    // 防げない (state 更新は次のレンダーで反映)。DOM 直の form.dataset を
+    // 同期フラグとして使うことで、同一レンダー内の二重 PATCH を確実に遮断する。
+    // ワンタイムトークンの失効レース防止のため必須。
+    const form = e.currentTarget;
+    if (form.dataset.submitting === "true") {
       return;
     }
 
@@ -83,6 +100,7 @@ const PasswordResetConfirm = () => {
       return;
     }
 
+    form.dataset.submitting = "true";
     setLoading(true);
     setError("");
 
@@ -153,6 +171,8 @@ const PasswordResetConfirm = () => {
     } catch {
       setError("通信エラーが発生しました。");
     } finally {
+      // 同期フラグを解除して再送信を可能にする
+      form.dataset.submitting = "false";
       setLoading(false);
     }
   };

--- a/app/src/pages/PasswordResetConfirm.tsx
+++ b/app/src/pages/PasswordResetConfirm.tsx
@@ -25,9 +25,18 @@ const PasswordResetConfirm = () => {
     // backend のメールリンクはフラグメント (#reset_password_token=...) ベース。
     // クエリ文字列 (?reset_password_token=...) も後方互換のためフォールバック。
     // フラグメントを優先することで、サーバログ・Referer 経由の漏えいを最小化。
+    //
+    // URLSearchParams は HTML form encoding 仕様に従って "+" を空白として
+    // デコードする。Devise の reset_password_token は base64 系で "+" を含むことが
+    // あり、そのままだと壊れるため空白を "+" に戻して正規化する。
+    // (backend が ERB::Util.url_encode で %2B にしている場合は影響しないが、
+    //  defense-in-depth として常に補正する)
+    const normalizeToken = (value: string | null) =>
+      value ? value.replace(/ /g, "+") : null;
+
     const hashParams = new URLSearchParams(location.hash.slice(1));
-    const tokenFromHash = hashParams.get(TOKEN_STORAGE_KEY);
-    const tokenFromQuery = searchParams.get(TOKEN_STORAGE_KEY);
+    const tokenFromHash = normalizeToken(hashParams.get(TOKEN_STORAGE_KEY));
+    const tokenFromQuery = normalizeToken(searchParams.get(TOKEN_STORAGE_KEY));
     const tokenFromUrl = tokenFromHash || tokenFromQuery;
 
     if (tokenFromUrl) {

--- a/app/src/pages/PasswordResetConfirm.tsx
+++ b/app/src/pages/PasswordResetConfirm.tsx
@@ -77,6 +77,7 @@ const PasswordResetConfirm = () => {
         // 再リロードでも壊れた状態から復帰できるようにする
         if ([401, 404, 422].includes(response.status)) {
           sessionStorage.removeItem(TOKEN_STORAGE_KEY);
+          setToken("");
         }
         setError(errors);
         return;

--- a/app/src/pages/PasswordResetConfirm.tsx
+++ b/app/src/pages/PasswordResetConfirm.tsx
@@ -2,7 +2,7 @@
 // メール内リンクから遷移する新パスワード設定画面
 // URLクエリ ?reset_password_token=... を受け取り、新パスワードを設定する
 import Layout from "@/components/layouts/Layout";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useSearchParams, Link } from "react-router-dom";
 import LoadingSpinner from "@/components/atoms/LoadingSpinner";
 import { cn } from "@/components/utils/cn";
@@ -10,15 +10,17 @@ import { API_BASE } from "@/api/base";
 
 const PasswordResetConfirm = () => {
   const [searchParams] = useSearchParams();
-  // トークンは初回マウント時に1度だけ取得し、直後にURLから除去する
-  // （ブラウザ履歴・Referer経由での漏洩を防止）
-  const [token] = useState(() => {
-    const value = searchParams.get("reset_password_token") || "";
-    if (value) {
-      window.history.replaceState({}, document.title, window.location.pathname);
-    }
-    return value;
-  });
+  const [token] = useState(() => searchParams.get("reset_password_token") || "");
+
+  // マウント後にURLからトークンを除去（ブラウザ履歴・Referer経由での漏洩を防止）
+  useEffect(() => {
+    if (!token) return;
+    window.history.replaceState(
+      {},
+      document.title,
+      `${window.location.pathname}${window.location.hash}`,
+    );
+  }, [token]);
 
   const [password, setPassword] = useState("");
   const [passwordConfirmation, setPasswordConfirmation] = useState("");

--- a/app/src/pages/PasswordResetConfirm.tsx
+++ b/app/src/pages/PasswordResetConfirm.tsx
@@ -108,22 +108,25 @@ const PasswordResetConfirm = () => {
             : "パスワードの更新に失敗しました。リンクの有効期限切れの可能性があります。";
 
         // トークン失効系の検知:
-        //   1. 既知の失効ステータスコード (現 backend は 401 のみ。400/404/410 は将来の
-        //      backend 変更や別ルート経由のレスポンスへの defense-in-depth として広めに見る)
+        //   1. 失効を意図する明確なステータスコード (401 = 未認証 / 410 = リソース消滅)
+        //      400/404 は通常のリクエスト形式エラーやルート問題でも返るため、
+        //      無条件で token 破棄すると正規ユーザーが復旧できなくなる
         //   2. errors 配列の文言が明確に reset_password_token に紐づく場合のみ
         //      → 「Password confirmation is invalid」のような通常のバリデーション失敗で
         //         誤って token を破棄しないよう、文言マッチは reset_password_token 関連に限定。
         const hasTokenError =
-          [400, 401, 404, 410].includes(response.status) ||
+          [401, 410].includes(response.status) ||
           apiErrors.some((msg: unknown) => {
             const normalized = String(msg).toLowerCase();
             return (
               normalized.includes("reset_password_token") ||
               normalized.includes("reset password token") ||
               normalized.includes("expired token") ||
+              normalized.includes("invalid token") ||
               normalized.includes("リセットパスワードトークン") ||
               normalized.includes("リセット用トークン") ||
-              normalized.includes("期限切れ")
+              normalized.includes("期限切れ") ||
+              normalized.includes("無効なトークン")
             );
           });
 

--- a/app/src/pages/PasswordResetConfirm.tsx
+++ b/app/src/pages/PasswordResetConfirm.tsx
@@ -1,0 +1,209 @@
+// app/src/pages/PasswordResetConfirm.tsx
+// メール内リンクから遷移する新パスワード設定画面
+// URLクエリ ?reset_password_token=... を受け取り、新パスワードを設定する
+import Layout from "@/components/layouts/Layout";
+import { useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import LoadingSpinner from "@/components/atoms/LoadingSpinner";
+import { cn } from "@/components/utils/cn";
+import { API_BASE } from "@/api/base";
+
+const PasswordResetConfirm = () => {
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get("reset_password_token") || "";
+
+  const [password, setPassword] = useState("");
+  const [passwordConfirmation, setPasswordConfirmation] = useState("");
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!token) {
+      setError("リセットトークンが無効です。メール内のリンクから再度アクセスしてください。");
+      return;
+    }
+
+    if (password.length < 6) {
+      setError("パスワードは6文字以上で入力してください。");
+      return;
+    }
+
+    if (password !== passwordConfirmation) {
+      setError("パスワードが一致しません。");
+      return;
+    }
+
+    setLoading(true);
+    setError("");
+
+    try {
+      const response = await fetch(`${API_BASE}/auth/password`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          reset_password_token: token,
+          password,
+          password_confirmation: passwordConfirmation,
+        }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        const errors = Array.isArray(data.errors)
+          ? data.errors.join(", ")
+          : "パスワードの更新に失敗しました。リンクの有効期限切れの可能性があります。";
+        setError(errors);
+        return;
+      }
+
+      setSuccess(true);
+    } catch {
+      setError("通信エラーが発生しました。");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (success) {
+    return (
+      <Layout>
+        <div className="max-w-md mx-auto p-4 sm:p-6 lg:p-8 space-y-4">
+          <div className="p-6 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg">
+            <h2 className="text-lg font-semibold text-green-800 dark:text-green-300 mb-2">
+              パスワードを更新しました
+            </h2>
+            <p className="text-sm text-green-700 dark:text-green-400">
+              新しいパスワードでログインしてください。
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => navigate("/login")}
+            className={cn(
+              "w-full py-3 px-4 border border-transparent rounded-lg shadow-sm",
+              "text-sm font-medium text-white",
+              "bg-blue-600 hover:bg-blue-700",
+              "focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500",
+            )}
+          >
+            ログイン画面へ
+          </button>
+        </div>
+      </Layout>
+    );
+  }
+
+  return (
+    <Layout>
+      <div className="max-w-md mx-auto p-4 sm:p-6 lg:p-8 space-y-4">
+        <div className="text-center mb-8">
+          <h1 className="text-xl sm:text-2xl lg:text-3xl font-bold text-gray-900 dark:text-white">
+            新しいパスワードの設定
+          </h1>
+          <p className="text-gray-600 dark:text-gray-400 mt-2">
+            新しいパスワードを入力してください
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="space-y-2">
+            <label
+              htmlFor="password"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+            >
+              新しいパスワード
+            </label>
+            <input
+              id="password"
+              type="password"
+              required
+              minLength={6}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              disabled={loading}
+              className={cn(
+                "w-full px-4 py-3 border rounded-lg",
+                "border-gray-300 dark:border-gray-600",
+                "bg-white dark:bg-gray-700",
+                "text-gray-900 dark:text-white",
+                "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent",
+                "disabled:opacity-50",
+                "transition duration-200",
+              )}
+              placeholder="6文字以上"
+              autoComplete="new-password"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label
+              htmlFor="password_confirmation"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+            >
+              新しいパスワード（確認）
+            </label>
+            <input
+              id="password_confirmation"
+              type="password"
+              required
+              minLength={6}
+              value={passwordConfirmation}
+              onChange={(e) => setPasswordConfirmation(e.target.value)}
+              disabled={loading}
+              className={cn(
+                "w-full px-4 py-3 border rounded-lg",
+                "border-gray-300 dark:border-gray-600",
+                "bg-white dark:bg-gray-700",
+                "text-gray-900 dark:text-white",
+                "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent",
+                "disabled:opacity-50",
+                "transition duration-200",
+              )}
+              placeholder="もう一度入力してください"
+              autoComplete="new-password"
+            />
+          </div>
+
+          {error && (
+            <div
+              className="p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg"
+              role="alert"
+            >
+              <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+            </div>
+          )}
+
+          <button
+            type="submit"
+            disabled={loading || !password || !passwordConfirmation}
+            className={cn(
+              "w-full py-3 px-4 border border-transparent rounded-lg shadow-sm",
+              "text-sm font-medium text-white",
+              "bg-blue-600 hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-600",
+              "focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500",
+              "disabled:opacity-50 disabled:cursor-not-allowed",
+              "transition duration-200 ease-in-out",
+            )}
+          >
+            {loading ? (
+              <div className="flex items-center justify-center">
+                <LoadingSpinner size="sm" className="mr-2" />
+                更新中...
+              </div>
+            ) : (
+              "パスワードを更新"
+            )}
+          </button>
+        </form>
+      </div>
+    </Layout>
+  );
+};
+
+export default PasswordResetConfirm;

--- a/app/src/pages/PasswordResetConfirm.tsx
+++ b/app/src/pages/PasswordResetConfirm.tsx
@@ -29,7 +29,8 @@ const PasswordResetConfirm = () => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    if (password.length < 6) {
+    // 空白のみの入力を弾くため trim 後に長さを検証
+    if (password.trim().length < 6) {
       setError("パスワードは6文字以上で入力してください。");
       return;
     }

--- a/app/src/pages/PasswordResetConfirm.tsx
+++ b/app/src/pages/PasswordResetConfirm.tsx
@@ -94,10 +94,16 @@ const PasswordResetConfirm = () => {
         const errors = Array.isArray(data.errors)
           ? data.errors.join(", ")
           : "パスワードの更新に失敗しました。リンクの有効期限切れの可能性があります。";
-        // トークン失効系のエラー時は sessionStorage からも破棄し、
-        // 再リロードでも壊れた状態から復帰できるようにする
-        if ([401, 404, 422].includes(response.status)) {
-          sessionStorage.removeItem(TOKEN_STORAGE_KEY);
+        // トークン失効系のエラー（401/404）時は sessionStorage からも破棄し、
+        // 再リロードでも壊れた状態から復帰できるようにする。
+        // 422 はパスワード強度などの通常バリデーション失敗にも使われるため除外し、
+        // 正しいリンクで再入力できるようにする。
+        if ([401, 404].includes(response.status)) {
+          try {
+            sessionStorage.removeItem(TOKEN_STORAGE_KEY);
+          } catch {
+            // ストレージ制限下でもエラー表示は継続する
+          }
           setToken("");
         }
         setError(errors);
@@ -105,7 +111,12 @@ const PasswordResetConfirm = () => {
       }
 
       // 成功後は sessionStorage のトークンを破棄（再利用防止）
-      sessionStorage.removeItem(TOKEN_STORAGE_KEY);
+      // ストレージ制限下で例外が出ても、更新成功画面は表示する
+      try {
+        sessionStorage.removeItem(TOKEN_STORAGE_KEY);
+      } catch {
+        // no-op
+      }
       setSuccess(true);
     } catch {
       setError("通信エラーが発生しました。");

--- a/app/src/pages/PasswordResetConfirm.tsx
+++ b/app/src/pages/PasswordResetConfirm.tsx
@@ -20,19 +20,27 @@ const PasswordResetConfirm = () => {
   // マウント中に searchParams が変化しても（同じ画面で別リンクを踏んだ場合など）、
   // useEffect で追従してトークンを更新できる
   useEffect(() => {
-    const tokenFromUrl = searchParams.get(TOKEN_STORAGE_KEY);
+    // backend のメールリンクはフラグメント (#reset_password_token=...) ベース。
+    // クエリ文字列 (?reset_password_token=...) も後方互換のためフォールバック。
+    // フラグメントを優先することで、サーバログ・Referer 経由の漏えいを最小化。
+    const hashParams = new URLSearchParams(window.location.hash.slice(1));
+    const tokenFromHash = hashParams.get(TOKEN_STORAGE_KEY);
+    const tokenFromQuery = searchParams.get(TOKEN_STORAGE_KEY);
+    const tokenFromUrl = tokenFromHash || tokenFromQuery;
+
     if (tokenFromUrl) {
       setToken(tokenFromUrl);
       // sessionStorage はプライベートブラウズや厳しいストレージ制限下で例外を投げ得る。
       // 失敗してもメイン処理は継続させ、URL からトークンが消えるだけの状態は避ける。
       try {
         sessionStorage.setItem(TOKEN_STORAGE_KEY, tokenFromUrl);
+        // クエリ・フラグメント両方を URL から除去する。
         // 第1引数は React Router の location.state を巻き込まないように
-        // 既存の history.state を保持する（{} に置換すると遷移情報が失われる）
+        // 既存の history.state を保持する（{} に置換すると遷移情報が失われる）。
         window.history.replaceState(
           window.history.state,
           document.title,
-          `${window.location.pathname}${window.location.hash}`,
+          window.location.pathname,
         );
       } catch {
         // sessionStorage / history が使えない環境では URL を残してトークンを保持する

--- a/app/src/pages/PasswordResetConfirm.tsx
+++ b/app/src/pages/PasswordResetConfirm.tsx
@@ -36,7 +36,7 @@ const PasswordResetConfirm = () => {
 
     try {
       const response = await fetch(`${API_BASE}/auth/password`, {
-        method: "PUT",
+        method: "PATCH",
         headers: {
           "Content-Type": "application/json",
         },

--- a/app/src/pages/PasswordResetConfirm.tsx
+++ b/app/src/pages/PasswordResetConfirm.tsx
@@ -45,7 +45,16 @@ const PasswordResetConfirm = () => {
       // 失敗してもメイン処理は継続させ、URL からトークンが消えるだけの状態は避ける。
       try {
         sessionStorage.setItem(TOKEN_STORAGE_KEY, tokenFromUrl);
-        // クエリ・フラグメント両方を URL から除去する。
+        // reset_password_token のみを URL から外科的に除去する。
+        // pathname だけに置き換えると、将来この画面に他のクエリ/ハッシュが
+        // 付いたときにそれらまで巻き込んで消えてしまうため。
+        const cleanedUrl = new URL(window.location.href);
+        cleanedUrl.searchParams.delete(TOKEN_STORAGE_KEY);
+        const remainingHash = new URLSearchParams(cleanedUrl.hash.slice(1));
+        remainingHash.delete(TOKEN_STORAGE_KEY);
+        const hashString = remainingHash.toString();
+        const nextUrl = `${cleanedUrl.pathname}${cleanedUrl.search}${hashString ? `#${hashString}` : ""}`;
+
         // 第1引数は React Router の location.state を巻き込まないように
         // 既存の history.state を保持する（{} に置換すると遷移情報が失われる）。
         // 同時に resetPasswordTokenLoaded フラグを history.state に記録することで、
@@ -54,7 +63,7 @@ const PasswordResetConfirm = () => {
         window.history.replaceState(
           { ...(window.history.state ?? {}), resetPasswordTokenLoaded: true },
           document.title,
-          window.location.pathname,
+          nextUrl,
         );
       } catch {
         // sessionStorage / history が使えない環境では URL を残してトークンを保持する
@@ -98,8 +107,16 @@ const PasswordResetConfirm = () => {
       return;
     }
 
-    // 空白のみの入力を弾くため trim 後に長さを検証
-    if (password.trim().length < 6) {
+    // 検証は実際に送信する password そのものに対して行う。
+    // 以前は trim().length で検証してたが、送信値は trim 前の生の password なので
+    // 検証基準と送信値がズレていた（例: "      hello1" は trim 後 6文字で通って
+    // 12文字のまま送られる）。
+    // 空白のみの入力は別条件で弾く。
+    if (password.trim().length === 0) {
+      setError("パスワードを入力してください。");
+      return;
+    }
+    if (password.length < 6) {
       setError("パスワードは6文字以上で入力してください。");
       return;
     }

--- a/app/src/pages/PasswordResetConfirm.tsx
+++ b/app/src/pages/PasswordResetConfirm.tsx
@@ -22,16 +22,28 @@ const PasswordResetConfirm = () => {
   useEffect(() => {
     const tokenFromUrl = searchParams.get(TOKEN_STORAGE_KEY);
     if (tokenFromUrl) {
-      sessionStorage.setItem(TOKEN_STORAGE_KEY, tokenFromUrl);
       setToken(tokenFromUrl);
-      window.history.replaceState(
-        {},
-        document.title,
-        `${window.location.pathname}${window.location.hash}`,
-      );
+      // sessionStorage はプライベートブラウズや厳しいストレージ制限下で例外を投げ得る。
+      // 失敗してもメイン処理は継続させ、URL からトークンが消えるだけの状態は避ける。
+      try {
+        sessionStorage.setItem(TOKEN_STORAGE_KEY, tokenFromUrl);
+        // 第1引数は React Router の location.state を巻き込まないように
+        // 既存の history.state を保持する（{} に置換すると遷移情報が失われる）
+        window.history.replaceState(
+          window.history.state,
+          document.title,
+          `${window.location.pathname}${window.location.hash}`,
+        );
+      } catch {
+        // sessionStorage / history が使えない環境では URL を残してトークンを保持する
+      }
       return;
     }
-    setToken(sessionStorage.getItem(TOKEN_STORAGE_KEY) || "");
+    try {
+      setToken(sessionStorage.getItem(TOKEN_STORAGE_KEY) || "");
+    } catch {
+      setToken("");
+    }
   }, [searchParams]);
 
   const [password, setPassword] = useState("");
@@ -42,6 +54,13 @@ const PasswordResetConfirm = () => {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+
+    // setLoading が反映される前に連続クリックされると、同じワンタイムトークンで
+    // PATCH が複数回飛んで失効レースが起こる。ボタン disabled に加えて
+    // ハンドラ先頭でも明示的に多重送信をブロック。
+    if (loading) {
+      return;
+    }
 
     // 空白のみの入力を弾くため trim 後に長さを検証
     if (password.trim().length < 6) {

--- a/app/src/pages/PasswordResetRequest.tsx
+++ b/app/src/pages/PasswordResetRequest.tsx
@@ -4,7 +4,7 @@
 // 唯一の admin にリセットメールを送信する
 import Layout from "@/components/layouts/Layout";
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import LoadingSpinner from "@/components/atoms/LoadingSpinner";
 import { cn } from "@/components/utils/cn";
 import { API_BASE } from "@/api/base";
@@ -14,7 +14,6 @@ const PasswordResetRequest = () => {
   const [error, setError] = useState("");
   const [success, setSuccess] = useState(false);
   const [loading, setLoading] = useState(false);
-  const navigate = useNavigate();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -68,13 +67,12 @@ const PasswordResetRequest = () => {
               数分経ってもメールが届かない場合は、合言葉をご確認の上、再度お試しください。
             </p>
           </div>
-          <button
-            type="button"
-            onClick={() => navigate("/login")}
+          <Link
+            to="/login"
             className="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
           >
             ← ログイン画面に戻る
-          </button>
+          </Link>
         </div>
       </Layout>
     );
@@ -154,13 +152,12 @@ const PasswordResetRequest = () => {
         </form>
 
         <div className="text-center">
-          <button
-            type="button"
-            onClick={() => navigate("/login")}
+          <Link
+            to="/login"
             className="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
           >
             ← ログイン画面に戻る
-          </button>
+          </Link>
         </div>
       </div>
     </Layout>

--- a/app/src/pages/PasswordResetRequest.tsx
+++ b/app/src/pages/PasswordResetRequest.tsx
@@ -36,17 +36,15 @@ const PasswordResetRequest = () => {
         body: JSON.stringify({ secret: secret.trim() }),
       });
 
-      if (response.status === 401) {
-        setError("合言葉が正しくありません。");
+      // 合言葉の正誤（401）を露出すると検証オラクルになるため、
+      // 成功時も認証失敗時も同じ画面を表示する。
+      // 正規ユーザーが合言葉を間違えた場合は「メールが届かない」ことで気付ける。
+      if (response.ok || response.status === 401) {
+        setSuccess(true);
         return;
       }
 
-      if (!response.ok) {
-        setError("リセットメールの送信に失敗しました。");
-        return;
-      }
-
-      setSuccess(true);
+      setError("リセットメールの送信に失敗しました。しばらくしてから再度お試しください。");
     } catch {
       setError("通信エラーが発生しました。");
     } finally {
@@ -60,11 +58,14 @@ const PasswordResetRequest = () => {
         <div className="max-w-md mx-auto p-4 sm:p-6 lg:p-8 space-y-4">
           <div className="p-6 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg">
             <h2 className="text-lg font-semibold text-green-800 dark:text-green-300 mb-2">
-              リセットメールを送信しました
+              リセット申請を受け付けました
             </h2>
             <p className="text-sm text-green-700 dark:text-green-400">
               管理者のメールアドレス宛にパスワードリセット用のリンクをお送りしました。
               メール内のリンクから新しいパスワードを設定してください。
+            </p>
+            <p className="text-xs text-green-700 dark:text-green-400 mt-3">
+              数分経ってもメールが届かない場合は、合言葉をご確認の上、再度お試しください。
             </p>
           </div>
           <button

--- a/app/src/pages/PasswordResetRequest.tsx
+++ b/app/src/pages/PasswordResetRequest.tsx
@@ -15,11 +15,14 @@ const PasswordResetRequest = () => {
   const [success, setSuccess] = useState(false);
   const [loading, setLoading] = useState(false);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    // setLoading が反映される前の連続クリックによる多重送信を防止する
-    if (loading) {
+    // setLoading の反映前に連続クリックされた場合の多重送信は React state では
+    // 防げない (state 更新は次のレンダーで反映)。DOM 直の form.dataset を
+    // 同期フラグとして使うことで、同一レンダー内の二重 POST を確実に遮断する。
+    const form = e.currentTarget;
+    if (form.dataset.submitting === "true") {
       return;
     }
 
@@ -28,6 +31,7 @@ const PasswordResetRequest = () => {
       return;
     }
 
+    form.dataset.submitting = "true";
     setLoading(true);
     setError("");
 
@@ -52,6 +56,8 @@ const PasswordResetRequest = () => {
     } catch {
       setError("通信エラーが発生しました。");
     } finally {
+      // 同期フラグを解除して再送信を可能にする
+      form.dataset.submitting = "false";
       setLoading(false);
     }
   };

--- a/app/src/pages/PasswordResetRequest.tsx
+++ b/app/src/pages/PasswordResetRequest.tsx
@@ -1,0 +1,169 @@
+// app/src/pages/PasswordResetRequest.tsx
+// パスワードリセット要求画面
+// 管理者は1人前提のため、Email入力ではなく SECRET 合言葉を入力して
+// 唯一の admin にリセットメールを送信する
+import Layout from "@/components/layouts/Layout";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import LoadingSpinner from "@/components/atoms/LoadingSpinner";
+import { cn } from "@/components/utils/cn";
+import { API_BASE } from "@/api/base";
+
+const PasswordResetRequest = () => {
+  const [secret, setSecret] = useState("");
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!secret.trim()) {
+      setError("合言葉を入力してください。");
+      return;
+    }
+
+    setLoading(true);
+    setError("");
+
+    try {
+      const response = await fetch(`${API_BASE}/auth/password`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ secret: secret.trim() }),
+      });
+
+      if (response.status === 401) {
+        setError("合言葉が正しくありません。");
+        return;
+      }
+
+      if (!response.ok) {
+        setError("リセットメールの送信に失敗しました。");
+        return;
+      }
+
+      setSuccess(true);
+    } catch {
+      setError("通信エラーが発生しました。");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (success) {
+    return (
+      <Layout>
+        <div className="max-w-md mx-auto p-4 sm:p-6 lg:p-8 space-y-4">
+          <div className="p-6 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg">
+            <h2 className="text-lg font-semibold text-green-800 dark:text-green-300 mb-2">
+              リセットメールを送信しました
+            </h2>
+            <p className="text-sm text-green-700 dark:text-green-400">
+              管理者のメールアドレス宛にパスワードリセット用のリンクをお送りしました。
+              メール内のリンクから新しいパスワードを設定してください。
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => navigate("/login")}
+            className="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
+          >
+            ← ログイン画面に戻る
+          </button>
+        </div>
+      </Layout>
+    );
+  }
+
+  return (
+    <Layout>
+      <div className="max-w-md mx-auto p-4 sm:p-6 lg:p-8 space-y-4">
+        <div className="text-center mb-8">
+          <h1 className="text-xl sm:text-2xl lg:text-3xl font-bold text-gray-900 dark:text-white">
+            パスワードリセット
+          </h1>
+          <p className="text-gray-600 dark:text-gray-400 mt-2">
+            合言葉を入力すると、管理者のメールアドレスにリセット用リンクを送信します。
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="space-y-2">
+            <label
+              htmlFor="secret"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+            >
+              合言葉
+            </label>
+            <input
+              id="secret"
+              type="password"
+              required
+              value={secret}
+              onChange={(e) => setSecret(e.target.value)}
+              disabled={loading}
+              className={cn(
+                "w-full px-4 py-3 border rounded-lg",
+                "border-gray-300 dark:border-gray-600",
+                "bg-white dark:bg-gray-700",
+                "text-gray-900 dark:text-white",
+                "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent",
+                "disabled:opacity-50 disabled:cursor-not-allowed",
+                "transition duration-200",
+              )}
+              placeholder="合言葉を入力してください"
+              autoComplete="off"
+            />
+          </div>
+
+          {error && (
+            <div
+              className="p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg"
+              role="alert"
+            >
+              <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+            </div>
+          )}
+
+          <button
+            type="submit"
+            disabled={loading || !secret.trim()}
+            className={cn(
+              "w-full py-3 px-4 border border-transparent rounded-lg shadow-sm",
+              "text-sm font-medium text-white",
+              "bg-blue-600 hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-600",
+              "focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500",
+              "disabled:opacity-50 disabled:cursor-not-allowed",
+              "transition duration-200 ease-in-out",
+            )}
+          >
+            {loading ? (
+              <div className="flex items-center justify-center">
+                <LoadingSpinner size="sm" className="mr-2" />
+                送信中...
+              </div>
+            ) : (
+              "リセットメールを送信"
+            )}
+          </button>
+        </form>
+
+        <div className="text-center">
+          <button
+            type="button"
+            onClick={() => navigate("/login")}
+            className="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
+          >
+            ← ログイン画面に戻る
+          </button>
+        </div>
+      </div>
+    </Layout>
+  );
+};
+
+export default PasswordResetRequest;

--- a/app/src/pages/PasswordResetRequest.tsx
+++ b/app/src/pages/PasswordResetRequest.tsx
@@ -36,10 +36,10 @@ const PasswordResetRequest = () => {
         body: JSON.stringify({ secret: secret.trim() }),
       });
 
-      // 合言葉の正誤（401）を露出すると検証オラクルになるため、
-      // 成功時も認証失敗時も同じ画面を表示する。
+      // Backend は合言葉の正誤に関わらず常に 202 Accepted を返すため、
+      // 2xx 系をそのまま成功扱いする。
       // 正規ユーザーが合言葉を間違えた場合は「メールが届かない」ことで気付ける。
-      if (response.ok || response.status === 401) {
+      if (response.ok) {
         setSuccess(true);
         return;
       }

--- a/app/src/pages/PasswordResetRequest.tsx
+++ b/app/src/pages/PasswordResetRequest.tsx
@@ -65,7 +65,8 @@ const PasswordResetRequest = () => {
               リセット申請を受け付けました
             </h2>
             <p className="text-sm text-green-700 dark:text-green-400">
-              管理者のメールアドレス宛にパスワードリセット用のリンクをお送りしました。
+              リセット申請を受け付けました。
+              合言葉が正しい場合は、管理者のメールアドレス宛にパスワードリセット用のリンクが送信されます。
               メール内のリンクから新しいパスワードを設定してください。
             </p>
             <p className="text-xs text-green-700 dark:text-green-400 mt-3">

--- a/app/src/pages/PasswordResetRequest.tsx
+++ b/app/src/pages/PasswordResetRequest.tsx
@@ -71,7 +71,6 @@ const PasswordResetRequest = () => {
               リセット申請を受け付けました
             </h2>
             <p className="text-sm text-green-700 dark:text-green-400">
-              リセット申請を受け付けました。
               合言葉が正しい場合は、管理者のメールアドレス宛にパスワードリセット用のリンクが送信されます。
               メール内のリンクから新しいパスワードを設定してください。
             </p>

--- a/app/src/pages/PasswordResetRequest.tsx
+++ b/app/src/pages/PasswordResetRequest.tsx
@@ -18,6 +18,11 @@ const PasswordResetRequest = () => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
+    // setLoading が反映される前の連続クリックによる多重送信を防止する
+    if (loading) {
+      return;
+    }
+
     if (!secret.trim()) {
       setError("合言葉を入力してください。");
       return;

--- a/app/src/router/Router.tsx
+++ b/app/src/router/Router.tsx
@@ -8,6 +8,8 @@ import PostDetail from "@/pages/PostDetail";
 import Admin from "@/pages/Admin";
 import Login from "@/pages/Login";
 import SignUp from "@/pages/SignUp";
+import PasswordResetRequest from "@/pages/PasswordResetRequest";
+import PasswordResetConfirm from "@/pages/PasswordResetConfirm";
 import { useAuth } from "@/hooks/useAuth";
 
 function AdminErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
@@ -68,6 +70,8 @@ const Router = () => {
       <Route path="/posts/:id" element={<PostDetail />} />
       <Route path="/login" element={<Login />} />
       <Route path="/signup" element={<SignUp />} />
+      <Route path="/password/reset" element={<PasswordResetRequest />} />
+      <Route path="/password/edit" element={<PasswordResetConfirm />} />
       <Route
         path="/admin"
         element={


### PR DESCRIPTION
## Summary
パスワードリセット機能のフロントエンド UI を実装。

## 変更内容
### 新規ページ
- **PasswordResetRequest** (`/password/reset`): 合言葉を入力してリセットメールを要求
- **PasswordResetConfirm** (`/password/edit`): メール内リンクから遷移、新パスワードを設定

### 既存ページ修正
- **Login**: 「パスワードをお忘れの方はこちら」リンクを追加
- **Router**: 新規ページのルートを追加

## 設計
管理者 1 人前提のため、一般的な「Email 入力 → リセット」ではなく、「合言葉入力 → 唯一の admin にメール送信」の設計。

### フロー
```
1. /login → 「パスワードをお忘れの方はこちら」をクリック
2. /password/reset → 合言葉を入力して送信
3. backend が SECRET 検証 → 一致すればメール送信
4. メール内リンク → /password/edit?reset_password_token=xxx
5. 新パスワードを2回入力 → 送信 → 完了
```

## 関連PR
- backend: [myblog-backend #67](https://github.com/terumitt-dev/myblog-backend/pull/67)（API実装）
- ops: [go-lilaregard-ops #220](https://github.com/terumitt-dev/go-lilaregard-ops/pull/220)（K8s Secret 注入）

## Test plan
- [ ] Drone CI グリーン
- [ ] 全 PR マージ後、`/login` → 「パスワードをお忘れの方」が表示される
- [ ] `/password/reset` で合言葉を入力して送信 → メール受信
- [ ] メール内リンクから `/password/edit` に遷移 → 新パスワード設定 → 完了
- [ ] 新パスワードでログイン成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)