### PR TITLE
feat: コメントフォームに Cloudflare Turnstile widget を組み込み

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -22,6 +22,11 @@ steps:
         from_secret: AWS_SECRET_ACCESS_KEY
       ECR_REGISTRY:
         from_secret: ECR_REGISTRY
+      # Cloudflare Turnstile widget Site Key (公開値だが、鍵ローテーションを
+      # 容易にするため Drone org Secret 経由で注入する)。
+      # docker build の --build-arg 経由で Vite ビルドに埋め込む。
+      VITE_TURNSTILE_SITE_KEY:
+        from_secret: VITE_TURNSTILE_SITE_KEY
     commands:
       - set -euo pipefail
       - echo "🐳 Starting Docker daemon..."
@@ -36,7 +41,11 @@ steps:
 
       # === CI: ビルド & 検証 ===
       - echo "🔨 Building Docker image..."
-      - docker build -f app/Dockerfile.prod --build-arg VITE_API_BASE_URL=/api -t go-lilaregard-frontend:ci app/
+      - |
+        docker build -f app/Dockerfile.prod \
+          --build-arg VITE_API_BASE_URL=/api \
+          --build-arg VITE_TURNSTILE_SITE_KEY=$VITE_TURNSTILE_SITE_KEY \
+          -t go-lilaregard-frontend:ci app/
       - echo "✅ Build succeeded"
 
       - echo ""

--- a/app/Dockerfile.prod
+++ b/app/Dockerfile.prod
@@ -15,6 +15,14 @@ COPY . .
 ARG VITE_API_BASE_URL=/api
 ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
 
+# Cloudflare Turnstile widget の Site Key (公開値)。
+# 未指定なら CommentForm 側で Cloudflare 公開テストキー (always pass) に
+# フォールバックする。本番ビルドは Drone CI で本物の Site Key を Drone Secret
+# 経由で渡す。Site Key は HTML に露出する公開情報なので Secret 化必須ではないが、
+# 鍵ローテーション容易性のため Drone org Secret 管理にしている。
+ARG VITE_TURNSTILE_SITE_KEY
+ENV VITE_TURNSTILE_SITE_KEY=$VITE_TURNSTILE_SITE_KEY
+
 RUN npm run build
 
 # ============================================

--- a/app/Dockerfile.prod
+++ b/app/Dockerfile.prod
@@ -16,12 +16,16 @@ ARG VITE_API_BASE_URL=/api
 ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
 
 # Cloudflare Turnstile widget の Site Key (公開値)。
-# 未指定なら CommentForm 側で Cloudflare 公開テストキー (always pass) に
-# フォールバックする。本番ビルドは Drone CI で本物の Site Key を Drone Secret
-# 経由で渡す。Site Key は HTML に露出する公開情報なので Secret 化必須ではないが、
+# 本番ビルドは Drone CI で本物の Site Key を Drone Secret 経由で渡す。
+# Site Key は HTML に露出する公開情報なので Secret 化必須ではないが、
 # 鍵ローテーション容易性のため Drone org Secret 管理にしている。
+# build 時に未設定だと CommentForm 側のロード時 throw で発火するため、
+# CI 上で即気付けるよう build 前にも必須チェックを置く (二重ガード)。
 ARG VITE_TURNSTILE_SITE_KEY
 ENV VITE_TURNSTILE_SITE_KEY=$VITE_TURNSTILE_SITE_KEY
+
+RUN test -n "$VITE_TURNSTILE_SITE_KEY" \
+  || (echo "VITE_TURNSTILE_SITE_KEY is required for production build" >&2; exit 1)
 
 RUN npm run build
 

--- a/app/index.html
+++ b/app/index.html
@@ -5,6 +5,13 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>My Blog (go-lilaregard)</title>
+    <!--
+      Cloudflare Turnstile widget script.
+      コメントフォームの bot 対策で使用 (TurnstileWidget.tsx)。
+      公式 endpoint から直接読み込むことで npm 依存を増やさず、
+      サプライチェーン経由のリスクを避けている。
+    -->
+    <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
   </head>
   <body>
     <div id="root"></div>

--- a/app/src/components/molecules/TurnstileWidget.tsx
+++ b/app/src/components/molecules/TurnstileWidget.tsx
@@ -1,0 +1,112 @@
+// src/components/molecules/TurnstileWidget.tsx
+import { useEffect, useRef } from "react";
+
+// Cloudflare Turnstile の最小限の型定義。
+// 公式 script を index.html から読み込む方式のため、グローバル window に
+// turnstile オブジェクトが生える。npm の型パッケージに依存せず手書きで定義し、
+// サプライチェーン経由のリスクを避けている。
+type TurnstileRenderOptions = {
+  sitekey: string;
+  callback: (token: string) => void;
+  "error-callback"?: () => void;
+  "expired-callback"?: () => void;
+  "timeout-callback"?: () => void;
+  theme?: "light" | "dark" | "auto";
+  size?: "normal" | "flexible" | "compact";
+  appearance?: "always" | "execute" | "interaction-only";
+};
+
+type TurnstileApi = {
+  render: (
+    element: HTMLElement | string,
+    options: TurnstileRenderOptions,
+  ) => string;
+  remove: (widgetId: string) => void;
+  reset: (widgetId?: string) => void;
+};
+
+declare global {
+  interface Window {
+    turnstile?: TurnstileApi;
+  }
+}
+
+type Props = {
+  siteKey: string;
+  onSuccess: (token: string) => void;
+  onError?: () => void;
+  onExpire?: () => void;
+  /**
+   * widget 描画後に reset を呼びたい (submit 成功後など) 場合に渡す。
+   * 値が変わった時に widget の token を破棄して再チャレンジを促す。
+   */
+  resetSignal?: number;
+};
+
+const TurnstileWidget = ({
+  siteKey,
+  onSuccess,
+  onError,
+  onExpire,
+  resetSignal,
+}: Props) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const widgetIdRef = useRef<string | null>(null);
+  // 初回マウント時の reset effect 実行を抑制するためのフラグ。
+  // 初期 resetSignal が 0 など defined な値で渡された場合に widget 描画直後に
+  // 不要な reset が走るのを防ぐ。
+  const isFirstResetRunRef = useRef(true);
+
+  // script は index.html で async defer 読み込み。マウント時点で
+  // window.turnstile が未定義のケースがあるため、ready ポーリングで
+  // 利用可能になってから render する。
+  useEffect(() => {
+    let cancelled = false;
+
+    const renderWhenReady = () => {
+      if (cancelled) return;
+      if (!containerRef.current) return;
+      if (!window.turnstile) {
+        // 50ms 間隔で短時間だけポーリング (実用上 1〜2 回で resolve する)
+        window.setTimeout(renderWhenReady, 50);
+        return;
+      }
+
+      widgetIdRef.current = window.turnstile.render(containerRef.current, {
+        sitekey: siteKey,
+        callback: onSuccess,
+        "error-callback": onError,
+        "expired-callback": onExpire,
+      });
+    };
+
+    renderWhenReady();
+
+    return () => {
+      cancelled = true;
+      if (widgetIdRef.current && window.turnstile) {
+        window.turnstile.remove(widgetIdRef.current);
+        widgetIdRef.current = null;
+      }
+    };
+    // siteKey が動的に変わるケースは想定していないが、安全側で deps に含める
+  }, [siteKey, onSuccess, onError, onExpire]);
+
+  // resetSignal が変化したら widget を reset (新しい token を取得しなおす)。
+  // 初回マウント時は (resetSignal の初期値が defined であっても) 実行しない
+  // — widget 描画直後の不要な reset を防ぐ。
+  useEffect(() => {
+    if (isFirstResetRunRef.current) {
+      isFirstResetRunRef.current = false;
+      return;
+    }
+    if (resetSignal === undefined) return;
+    if (widgetIdRef.current && window.turnstile) {
+      window.turnstile.reset(widgetIdRef.current);
+    }
+  }, [resetSignal]);
+
+  return <div ref={containerRef} />;
+};
+
+export default TurnstileWidget;

--- a/app/src/components/molecules/TurnstileWidget.tsx
+++ b/app/src/components/molecules/TurnstileWidget.tsx
@@ -41,7 +41,19 @@ type Props = {
    * 値が変わった時に widget の token を破棄して再チャレンジを促す。
    */
   resetSignal?: number;
+  /**
+   * Cloudflare Turnstile widget の表示テーマ。デフォルト "auto" で
+   * OS / ブラウザのダークモード設定に追従する。本ブログは Tailwind の dark:
+   * クラスで配色を切り替えているため、widget も追従させて見た目を統一する。
+   */
+  theme?: "light" | "dark" | "auto";
 };
+
+// script が広告ブロッカー / ネットワーク障害で読み込まれないケースでも
+// ポーリングが永続化しないよう上限を設ける。50ms × 100 = 約 5 秒。
+// この時間で window.turnstile が生えなければ onError を呼んで諦める。
+const SCRIPT_READY_POLL_INTERVAL_MS = 50;
+const SCRIPT_READY_MAX_RETRIES = 100;
 
 const TurnstileWidget = ({
   siteKey,
@@ -49,6 +61,7 @@ const TurnstileWidget = ({
   onError,
   onExpire,
   resetSignal,
+  theme = "auto",
 }: Props) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const widgetIdRef = useRef<string | null>(null);
@@ -60,15 +73,22 @@ const TurnstileWidget = ({
   // script は index.html で async defer 読み込み。マウント時点で
   // window.turnstile が未定義のケースがあるため、ready ポーリングで
   // 利用可能になってから render する。
+  // ポーリングは SCRIPT_READY_MAX_RETRIES 回で打ち切り、それまでに script が
+  // 来なければ onError を呼んで諦める (ad blocker や Cloudflare 障害対策)。
   useEffect(() => {
     let cancelled = false;
+    let retries = 0;
 
     const renderWhenReady = () => {
       if (cancelled) return;
       if (!containerRef.current) return;
       if (!window.turnstile) {
-        // 50ms 間隔で短時間だけポーリング (実用上 1〜2 回で resolve する)
-        window.setTimeout(renderWhenReady, 50);
+        if (retries >= SCRIPT_READY_MAX_RETRIES) {
+          onError?.();
+          return;
+        }
+        retries += 1;
+        window.setTimeout(renderWhenReady, SCRIPT_READY_POLL_INTERVAL_MS);
         return;
       }
 
@@ -77,6 +97,7 @@ const TurnstileWidget = ({
         callback: onSuccess,
         "error-callback": onError,
         "expired-callback": onExpire,
+        theme,
       });
     };
 
@@ -90,7 +111,7 @@ const TurnstileWidget = ({
       }
     };
     // siteKey が動的に変わるケースは想定していないが、安全側で deps に含める
-  }, [siteKey, onSuccess, onError, onExpire]);
+  }, [siteKey, onSuccess, onError, onExpire, theme]);
 
   // resetSignal が変化したら widget を reset (新しい token を取得しなおす)。
   // 初回マウント時は (resetSignal の初期値が defined であっても) 実行しない

--- a/app/src/components/molecules/TurnstileWidget.tsx
+++ b/app/src/components/molecules/TurnstileWidget.tsx
@@ -78,8 +78,14 @@ const TurnstileWidget = ({
   useEffect(() => {
     let cancelled = false;
     let retries = 0;
+    // ポーリング待機中の setTimeout ID。cleanup で確実に解除し、
+    // unmount 後にタイマーが残らないようにする (テストの fake timer 環境でも
+    // 後続テストへ漏れを防ぐ意図)。cancelled フラグだけでも動作は壊れないが、
+    // OS のタイマー資源を即座に手放す方が clean。
+    let pendingTimeoutId: number | null = null;
 
     const renderWhenReady = () => {
+      pendingTimeoutId = null;
       if (cancelled) return;
       if (!containerRef.current) return;
       if (!window.turnstile) {
@@ -88,7 +94,10 @@ const TurnstileWidget = ({
           return;
         }
         retries += 1;
-        window.setTimeout(renderWhenReady, SCRIPT_READY_POLL_INTERVAL_MS);
+        pendingTimeoutId = window.setTimeout(
+          renderWhenReady,
+          SCRIPT_READY_POLL_INTERVAL_MS,
+        );
         return;
       }
 
@@ -113,6 +122,10 @@ const TurnstileWidget = ({
 
     return () => {
       cancelled = true;
+      if (pendingTimeoutId !== null) {
+        window.clearTimeout(pendingTimeoutId);
+        pendingTimeoutId = null;
+      }
       if (widgetIdRef.current && window.turnstile) {
         window.turnstile.remove(widgetIdRef.current);
         widgetIdRef.current = null;

--- a/app/src/components/molecules/TurnstileWidget.tsx
+++ b/app/src/components/molecules/TurnstileWidget.tsx
@@ -92,13 +92,21 @@ const TurnstileWidget = ({
         return;
       }
 
-      widgetIdRef.current = window.turnstile.render(containerRef.current, {
-        sitekey: siteKey,
-        callback: onSuccess,
-        "error-callback": onError,
-        "expired-callback": onExpire,
-        theme,
-      });
+      // render() は通常 widget id を返すだけだが、不正な siteKey や script 側の
+      // 不具合で例外を投げるケースがある。catch せず外に伝播するとフォーム所属の
+      // ページ全体が React error boundary or Vite の overlay で壊れて見えるため、
+      // 例外時は onError に倒して既存のエラー表示パスに合流させる。
+      try {
+        widgetIdRef.current = window.turnstile.render(containerRef.current, {
+          sitekey: siteKey,
+          callback: onSuccess,
+          "error-callback": onError,
+          "expired-callback": onExpire,
+          theme,
+        });
+      } catch {
+        onError?.();
+      }
     };
 
     renderWhenReady();

--- a/app/src/components/molecules/__tests__/TurnstileWidget.test.tsx
+++ b/app/src/components/molecules/__tests__/TurnstileWidget.test.tsx
@@ -164,4 +164,54 @@ describe("TurnstileWidget", () => {
       ),
     ).not.toThrow();
   });
+
+  it("theme prop を render に渡すこと (デフォルトは auto)", async () => {
+    const { unmount } = render(
+      <TurnstileWidget siteKey="test-key" onSuccess={() => {}} />,
+    );
+    await waitFor(() => expect(mock.render).toHaveBeenCalled());
+    const defaultArgs = mock.render.mock.calls[0]?.[1] as { theme?: string };
+    expect(defaultArgs.theme).toBe("auto");
+    unmount();
+    mock.render.mockClear();
+
+    render(
+      <TurnstileWidget
+        siteKey="test-key"
+        onSuccess={() => {}}
+        theme="dark"
+      />,
+    );
+    await waitFor(() => expect(mock.render).toHaveBeenCalled());
+    const darkArgs = mock.render.mock.calls[0]?.[1] as { theme?: string };
+    expect(darkArgs.theme).toBe("dark");
+  });
+
+  it("window.turnstile が一定時間生えなければ onError を呼んでポーリングを止めること", async () => {
+    // script が永続的にロードされないケースをシミュレート。
+    delete (window as { turnstile?: unknown }).turnstile;
+    vi.useFakeTimers();
+
+    const onError = vi.fn();
+    render(
+      <TurnstileWidget
+        siteKey="test-key"
+        onSuccess={() => {}}
+        onError={onError}
+      />,
+    );
+
+    // SCRIPT_READY_MAX_RETRIES (100) * SCRIPT_READY_POLL_INTERVAL_MS (50) = 5000ms
+    // で諦める設計。余裕を持って 6 秒進める。
+    await vi.advanceTimersByTimeAsync(6000);
+
+    expect(onError).toHaveBeenCalledTimes(1);
+
+    // さらに時間を進めても再度 onError が呼ばれないこと (ポーリングが止まっている)
+    onError.mockClear();
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(onError).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
 });

--- a/app/src/components/molecules/__tests__/TurnstileWidget.test.tsx
+++ b/app/src/components/molecules/__tests__/TurnstileWidget.test.tsx
@@ -1,0 +1,167 @@
+// app/src/components/molecules/__tests__/TurnstileWidget.test.tsx
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, cleanup, waitFor, act } from "@testing-library/react";
+import TurnstileWidget from "../TurnstileWidget";
+
+// window.turnstile (Cloudflare 公式 script が生やすグローバル) をモックする。
+// 実 script を読み込まないので、jsdom 環境では手動で window.turnstile を
+// 差し込んで render / remove / reset の呼び出しを検証する。
+type TurnstileMock = {
+  render: ReturnType<typeof vi.fn>;
+  remove: ReturnType<typeof vi.fn>;
+  reset: ReturnType<typeof vi.fn>;
+  triggerSuccess: (token: string) => void;
+  triggerError: () => void;
+  triggerExpire: () => void;
+};
+
+const installTurnstileMock = (): TurnstileMock => {
+  const callbacks: {
+    success: ((token: string) => void) | null;
+    error: (() => void) | null;
+    expire: (() => void) | null;
+  } = {
+    success: null,
+    error: null,
+    expire: null,
+  };
+
+  const renderFn = vi.fn(
+    (
+      _el: HTMLElement,
+      options: {
+        callback?: (token: string) => void;
+        "error-callback"?: () => void;
+        "expired-callback"?: () => void;
+      },
+    ) => {
+      callbacks.success = options.callback ?? null;
+      callbacks.error = options["error-callback"] ?? null;
+      callbacks.expire = options["expired-callback"] ?? null;
+      return "widget-id-stub";
+    },
+  );
+  const removeFn = vi.fn();
+  const resetFn = vi.fn();
+
+  (window as { turnstile?: unknown }).turnstile = {
+    render: renderFn,
+    remove: removeFn,
+    reset: resetFn,
+  };
+
+  return {
+    render: renderFn,
+    remove: removeFn,
+    reset: resetFn,
+    triggerSuccess: (token: string) => callbacks.success?.(token),
+    triggerError: () => callbacks.error?.(),
+    triggerExpire: () => callbacks.expire?.(),
+  };
+};
+
+describe("TurnstileWidget", () => {
+  let mock: TurnstileMock;
+
+  beforeEach(() => {
+    mock = installTurnstileMock();
+  });
+
+  afterEach(() => {
+    cleanup();
+    delete (window as { turnstile?: unknown }).turnstile;
+  });
+
+  it("マウント時に window.turnstile.render を sitekey 付きで呼ぶこと", async () => {
+    render(
+      <TurnstileWidget siteKey="test-key" onSuccess={() => {}} />,
+    );
+
+    await waitFor(() => {
+      expect(mock.render).toHaveBeenCalledTimes(1);
+    });
+    const renderArgs = mock.render.mock.calls[0]?.[1] as {
+      sitekey: string;
+    };
+    expect(renderArgs.sitekey).toBe("test-key");
+  });
+
+  it("Cloudflare からの token 受領を onSuccess に伝播すること", async () => {
+    const onSuccess = vi.fn();
+    render(<TurnstileWidget siteKey="test-key" onSuccess={onSuccess} />);
+
+    await waitFor(() => expect(mock.render).toHaveBeenCalled());
+    act(() => {
+      mock.triggerSuccess("token-abc");
+    });
+
+    expect(onSuccess).toHaveBeenCalledWith("token-abc");
+  });
+
+  it("onError / onExpire が指定されていれば widget から伝播されること", async () => {
+    const onError = vi.fn();
+    const onExpire = vi.fn();
+    render(
+      <TurnstileWidget
+        siteKey="test-key"
+        onSuccess={() => {}}
+        onError={onError}
+        onExpire={onExpire}
+      />,
+    );
+
+    await waitFor(() => expect(mock.render).toHaveBeenCalled());
+    act(() => {
+      mock.triggerError();
+      mock.triggerExpire();
+    });
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onExpire).toHaveBeenCalledTimes(1);
+  });
+
+  it("アンマウント時に widget を remove すること (cleanup)", async () => {
+    const { unmount } = render(
+      <TurnstileWidget siteKey="test-key" onSuccess={() => {}} />,
+    );
+
+    await waitFor(() => expect(mock.render).toHaveBeenCalled());
+    unmount();
+
+    expect(mock.remove).toHaveBeenCalledWith("widget-id-stub");
+  });
+
+  it("resetSignal が変化すると window.turnstile.reset を呼ぶこと", async () => {
+    const { rerender } = render(
+      <TurnstileWidget
+        siteKey="test-key"
+        onSuccess={() => {}}
+        resetSignal={0}
+      />,
+    );
+
+    await waitFor(() => expect(mock.render).toHaveBeenCalled());
+    // 初回 effect で reset は呼ばれない設計 (依存値が defined なだけでは reset しない)
+    expect(mock.reset).not.toHaveBeenCalled();
+
+    rerender(
+      <TurnstileWidget
+        siteKey="test-key"
+        onSuccess={() => {}}
+        resetSignal={1}
+      />,
+    );
+
+    expect(mock.reset).toHaveBeenCalledWith("widget-id-stub");
+  });
+
+  it("window.turnstile 未定義の状態でも crash しないこと (script load 遅延)", () => {
+    delete (window as { turnstile?: unknown }).turnstile;
+
+    expect(() =>
+      render(
+        <TurnstileWidget siteKey="test-key" onSuccess={() => {}} />,
+      ),
+    ).not.toThrow();
+  });
+});

--- a/app/src/components/molecules/__tests__/TurnstileWidget.test.tsx
+++ b/app/src/components/molecules/__tests__/TurnstileWidget.test.tsx
@@ -68,6 +68,11 @@ describe("TurnstileWidget", () => {
   });
 
   afterEach(() => {
+    // fake timers を使うテストが途中で失敗した場合に、復元漏れで
+    // 後続テストが fake timer のまま走ってフレーキー化するのを防ぐため
+    // ここで一括復元する (各テスト末尾での useRealTimers ではなく集約方式)。
+    vi.clearAllTimers();
+    vi.useRealTimers();
     cleanup();
     delete (window as { turnstile?: unknown }).turnstile;
   });
@@ -231,7 +236,6 @@ describe("TurnstileWidget", () => {
     onError.mockClear();
     await vi.advanceTimersByTimeAsync(5000);
     expect(onError).not.toHaveBeenCalled();
-
-    vi.useRealTimers();
+    // useRealTimers は afterEach で集約復元する (途中失敗時の漏洩対策)。
   });
 });

--- a/app/src/components/molecules/__tests__/TurnstileWidget.test.tsx
+++ b/app/src/components/molecules/__tests__/TurnstileWidget.test.tsx
@@ -187,6 +187,26 @@ describe("TurnstileWidget", () => {
     expect(darkArgs.theme).toBe("dark");
   });
 
+  it("window.turnstile.render が例外を投げたら onError に倒すこと (app crash 防止)", async () => {
+    const onError = vi.fn();
+    // render を throw に差し替え
+    mock.render.mockImplementation(() => {
+      throw new Error("render failed");
+    });
+
+    expect(() =>
+      render(
+        <TurnstileWidget
+          siteKey="test-key"
+          onSuccess={() => {}}
+          onError={onError}
+        />,
+      ),
+    ).not.toThrow();
+
+    await waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
+  });
+
   it("window.turnstile が一定時間生えなければ onError を呼んでポーリングを止めること", async () => {
     // script が永続的にロードされないケースをシミュレート。
     delete (window as { turnstile?: unknown }).turnstile;

--- a/app/src/components/organisms/CommentForm.tsx
+++ b/app/src/components/organisms/CommentForm.tsx
@@ -42,11 +42,16 @@ const TURNSTILE_ERROR_MESSAGES: Record<Exclude<TurnstileErrorState, null>, strin
 };
 
 type Props = {
+  /**
+   * 送信処理。Promise を返す場合はその解決を待ってから入力欄をクリアする
+   * (失敗 = reject なら入力欄を保持してユーザーがリトライできるようにする)。
+   * 同期実装 (void 返却) もサポートし、その場合は従来通り即クリアする。
+   */
   onSubmit: (
     userName: string,
     comment: string,
     turnstileToken: string,
-  ) => void;
+  ) => void | Promise<void>;
   onCancel: () => void;
   disabled?: boolean;
 };
@@ -85,20 +90,31 @@ const CommentForm = ({ onSubmit, onCancel, disabled = false }: Props) => {
     setTurnstileError("error");
   }, []);
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (
-      userName.trim() &&
-      comment.trim() &&
-      turnstileToken &&
-      !disabled
+      !userName.trim() ||
+      !comment.trim() ||
+      !turnstileToken ||
+      disabled
     ) {
-      onSubmit(userName, comment, turnstileToken);
-      setUserName("");
-      setComment("");
-      // 次の投稿用に widget を reset し、再 challenge を求める。
-      setTurnstileToken(null);
-      setResetSignal((prev) => prev + 1);
+      return;
     }
+
+    try {
+      // onSubmit が同期 (void) の場合も await で素通りする。
+      // 非同期 (Promise) を返す場合は完了/失敗を待ってから次の処理に進む。
+      await onSubmit(userName, comment, turnstileToken);
+    } catch {
+      // 投稿失敗時は入力欄と token を保持し、ユーザーが再投稿できるようにする。
+      // エラー表示は親 (PostDetail) 側の責務。
+      return;
+    }
+
+    setUserName("");
+    setComment("");
+    // 次の投稿用に widget を reset し、再 challenge を求める。
+    setTurnstileToken(null);
+    setResetSignal((prev) => prev + 1);
   };
 
   // 送信ボタンの disabled 判定: 親からの disabled に加えて、

--- a/app/src/components/organisms/CommentForm.tsx
+++ b/app/src/components/organisms/CommentForm.tsx
@@ -1,5 +1,5 @@
 // src/components/organisms/CommentForm.tsx
-import { useState, useId, useCallback } from "react";
+import { useState, useId, useCallback, useRef } from "react";
 import Input from "@/components/atoms/Input";
 import Textarea from "@/components/atoms/Textarea";
 import CommentButtons from "@/components/molecules/CommentButtons";
@@ -72,6 +72,13 @@ const CommentForm = ({ onSubmit, onCancel, disabled = false }: Props) => {
   // (token を null にするだけだとボタンが急に disabled になる理由が伝わらない)。
   const [turnstileError, setTurnstileError] =
     useState<TurnstileErrorState>(null);
+  // 二重送信防止:
+  // - isSubmittingRef: 同期的な再入ガード (ref は即時反映、state の render lag を
+  //   待たない)。await 中の連打で同じ Turnstile token が使い回されるのを防ぐ。
+  // - isSubmitting: UI 反映用 (submit ボタンの disabled、視覚的フィードバック)。
+  // 両者を組み合わせることで、視覚的にも論理的にも二重送信を弾く。
+  const isSubmittingRef = useRef(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const userNameId = useId();
   const commentId = useId();
@@ -96,6 +103,11 @@ const CommentForm = ({ onSubmit, onCancel, disabled = false }: Props) => {
   }, []);
 
   const handleSubmit = async () => {
+    // 同期的な再入ガード。state ベースの isSubmitting は次回 render まで
+    // 反映されないので、その間の連打を ref で確実に弾く。
+    if (isSubmittingRef.current) {
+      return;
+    }
     if (
       !userName.trim() ||
       !comment.trim() ||
@@ -104,6 +116,9 @@ const CommentForm = ({ onSubmit, onCancel, disabled = false }: Props) => {
     ) {
       return;
     }
+
+    isSubmittingRef.current = true;
+    setIsSubmitting(true);
 
     try {
       // onSubmit が同期 (void) の場合も await で素通りする。
@@ -130,6 +145,10 @@ const CommentForm = ({ onSubmit, onCancel, disabled = false }: Props) => {
       setTurnstileError("submit_failed");
       setResetSignal((prev) => prev + 1);
       return;
+    } finally {
+      // 成功 / 失敗のどちらの経路でも送信中フラグを解除する。
+      isSubmittingRef.current = false;
+      setIsSubmitting(false);
     }
 
     setUserName("");
@@ -139,10 +158,16 @@ const CommentForm = ({ onSubmit, onCancel, disabled = false }: Props) => {
     setResetSignal((prev) => prev + 1);
   };
 
-  // 送信ボタンの disabled 判定: 親からの disabled に加えて、
-  // 入力欠落 / Turnstile 未完了のいずれかを満たさない場合も送信不可。
+  // 送信ボタンの disabled 判定: 親からの disabled / 入力欠落 / Turnstile 未完了 /
+  // 送信中 (isSubmitting) のいずれかを満たす場合は送信不可。
+  // 親 (PostDetail) も `disabled={isSubmittingComment}` を渡すが、その state 反映には
+  // re-render を待つため、CommentForm 内の isSubmitting でも視覚的に即時 disable する。
   const submitDisabled =
-    disabled || !userName.trim() || !comment.trim() || !turnstileToken;
+    isSubmitting ||
+    disabled ||
+    !userName.trim() ||
+    !comment.trim() ||
+    !turnstileToken;
 
   return (
     <div className="flex flex-col gap-3 p-4 rounded-lg bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600">

--- a/app/src/components/organisms/CommentForm.tsx
+++ b/app/src/components/organisms/CommentForm.tsx
@@ -1,11 +1,24 @@
 // src/components/organisms/CommentForm.tsx
-import { useState, useId } from "react";
+import { useState, useId, useCallback } from "react";
 import Input from "@/components/atoms/Input";
 import Textarea from "@/components/atoms/Textarea";
 import CommentButtons from "@/components/molecules/CommentButtons";
+import TurnstileWidget from "@/components/molecules/TurnstileWidget";
+
+// Cloudflare Turnstile の Site Key。
+// dev / test では Cloudflare 公開のテストキー (always pass) をデフォルトに
+// フォールバックする。本番ビルドは Drone CI が --build-arg VITE_TURNSTILE_SITE_KEY
+// で本物の Site Key を埋め込む (app/Dockerfile.prod 参照)。
+// https://developers.cloudflare.com/turnstile/troubleshooting/testing/
+const TURNSTILE_SITE_KEY =
+  import.meta.env.VITE_TURNSTILE_SITE_KEY ?? "1x00000000000000000000AA";
 
 type Props = {
-  onSubmit: (userName: string, comment: string) => void;
+  onSubmit: (
+    userName: string,
+    comment: string,
+    turnstileToken: string,
+  ) => void;
   onCancel: () => void;
   disabled?: boolean;
 };
@@ -13,17 +26,48 @@ type Props = {
 const CommentForm = ({ onSubmit, onCancel, disabled = false }: Props) => {
   const [userName, setUserName] = useState("");
   const [comment, setComment] = useState("");
+  // Turnstile 検証 token。widget が解決し終わるまでは null。
+  const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
+  // submit 成功後に widget を reset するためのカウンタ。
+  const [resetSignal, setResetSignal] = useState(0);
 
   const userNameId = useId();
   const commentId = useId();
 
+  const handleTurnstileSuccess = useCallback((token: string) => {
+    setTurnstileToken(token);
+  }, []);
+
+  const handleTurnstileExpire = useCallback(() => {
+    // token の有効期限切れ。submit を再度ブロックするため state をクリアする。
+    setTurnstileToken(null);
+  }, []);
+
+  const handleTurnstileError = useCallback(() => {
+    // widget 側のエラー (ネットワーク断など)。token を無効化して再 challenge 待ち。
+    setTurnstileToken(null);
+  }, []);
+
   const handleSubmit = () => {
-    if (userName.trim() && comment.trim() && !disabled) {
-      onSubmit(userName, comment);
+    if (
+      userName.trim() &&
+      comment.trim() &&
+      turnstileToken &&
+      !disabled
+    ) {
+      onSubmit(userName, comment, turnstileToken);
       setUserName("");
       setComment("");
+      // 次の投稿用に widget を reset し、再 challenge を求める。
+      setTurnstileToken(null);
+      setResetSignal((prev) => prev + 1);
     }
   };
+
+  // 送信ボタンの disabled 判定: 親からの disabled に加えて、
+  // 入力欠落 / Turnstile 未完了のいずれかを満たさない場合も送信不可。
+  const submitDisabled =
+    disabled || !userName.trim() || !comment.trim() || !turnstileToken;
 
   return (
     <div className="flex flex-col gap-3 p-4 rounded-lg bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600">
@@ -42,10 +86,17 @@ const CommentForm = ({ onSubmit, onCancel, disabled = false }: Props) => {
         disabled={disabled}
         rows={4}
       />
+      <TurnstileWidget
+        siteKey={TURNSTILE_SITE_KEY}
+        onSuccess={handleTurnstileSuccess}
+        onExpire={handleTurnstileExpire}
+        onError={handleTurnstileError}
+        resetSignal={resetSignal}
+      />
       <CommentButtons
         onSubmit={handleSubmit}
         onCancel={onCancel}
-        disabled={disabled}
+        disabled={submitDisabled}
       />
     </div>
   );

--- a/app/src/components/organisms/CommentForm.tsx
+++ b/app/src/components/organisms/CommentForm.tsx
@@ -32,13 +32,18 @@ if (!TURNSTILE_SITE_KEY) {
 // - null: エラー無し
 // - "error": widget のロード失敗 / script ブロック / network 断 等
 // - "expire": token の有効期限切れ (Cloudflare が再 challenge を促す状態)
+// - "submit_failed": 投稿失敗で token を破棄して widget を reset した状態
+//   (alert だけだと「なぜ再度認証が必要なのか」が伝わらないため、
+//    widget 直下にも理由をテキストで提示する)
 // 文言を分けることでユーザーが原因を把握しやすくする。
-type TurnstileErrorState = null | "error" | "expire";
+type TurnstileErrorState = null | "error" | "expire" | "submit_failed";
 
 const TURNSTILE_ERROR_MESSAGES: Record<Exclude<TurnstileErrorState, null>, string> = {
   error:
     "認証 widget の読み込みに失敗しました。ネットワーク状況を確認し、ページを再読み込みしてください。",
   expire: "認証の有効期限が切れました。widget を再度お試しください。",
+  submit_failed:
+    "投稿が失敗しました。認証 widget を再度解いてから、もう一度お試しください。",
 };
 
 type Props = {
@@ -108,6 +113,9 @@ const CommentForm = ({ onSubmit, onCancel, disabled = false }: Props) => {
       // 投稿失敗時の方針:
       // - 入力欄 (userName / comment) は保持 → ユーザーが内容を再入力せずに済む
       // - Turnstile token は破棄 + widget reset → token 再利用の事故を防ぐ
+      // - turnstileError = "submit_failed" → widget 直下に「再認証が必要」
+      //   メッセージを表示 (親の alert だけでは widget を再解決する理由が
+      //   伝わらないため)
       //
       // 理由: Cloudflare Turnstile の token は single-use で、backend の
       // siteverify が 1 度通った時点で消費される (再 verify は失敗する仕様)。
@@ -117,8 +125,9 @@ const CommentForm = ({ onSubmit, onCancel, disabled = false }: Props) => {
       // ネットワーク断のような「backend 到達せず token 未消費」のケースでは
       // widget 再解決が必要になるが、auto/managed テーマは概ね invisible で
       // 解決するので UX 損失は限定的、トレードオフとして受容する。
-      // エラー表示は親 (PostDetail) 側の責務。
+      // 投稿失敗の通知 (alert 等) は親 (PostDetail) 側の責務。
       setTurnstileToken(null);
+      setTurnstileError("submit_failed");
       setResetSignal((prev) => prev + 1);
       return;
     }

--- a/app/src/components/organisms/CommentForm.tsx
+++ b/app/src/components/organisms/CommentForm.tsx
@@ -105,8 +105,21 @@ const CommentForm = ({ onSubmit, onCancel, disabled = false }: Props) => {
       // 非同期 (Promise) を返す場合は完了/失敗を待ってから次の処理に進む。
       await onSubmit(userName, comment, turnstileToken);
     } catch {
-      // 投稿失敗時は入力欄と token を保持し、ユーザーが再投稿できるようにする。
+      // 投稿失敗時の方針:
+      // - 入力欄 (userName / comment) は保持 → ユーザーが内容を再入力せずに済む
+      // - Turnstile token は破棄 + widget reset → token 再利用の事故を防ぐ
+      //
+      // 理由: Cloudflare Turnstile の token は single-use で、backend の
+      // siteverify が 1 度通った時点で消費される (再 verify は失敗する仕様)。
+      // 失敗の原因が verify 通過後の処理 (例: DB validation エラー) だった場合、
+      // token を保持して再 submit すると backend で再び 422 "認証に失敗" になり、
+      // ユーザーは原因不明のループに陥る。
+      // ネットワーク断のような「backend 到達せず token 未消費」のケースでは
+      // widget 再解決が必要になるが、auto/managed テーマは概ね invisible で
+      // 解決するので UX 損失は限定的、トレードオフとして受容する。
       // エラー表示は親 (PostDetail) 側の責務。
+      setTurnstileToken(null);
+      setResetSignal((prev) => prev + 1);
       return;
     }
 

--- a/app/src/components/organisms/CommentForm.tsx
+++ b/app/src/components/organisms/CommentForm.tsx
@@ -33,8 +33,8 @@ if (!TURNSTILE_SITE_KEY) {
 // - "error": widget のロード失敗 / script ブロック / network 断 等
 // - "expire": token の有効期限切れ (Cloudflare が再 challenge を促す状態)
 // - "submit_failed": 投稿失敗で token を破棄して widget を reset した状態
-//   (alert だけだと「なぜ再度認証が必要なのか」が伝わらないため、
-//    widget 直下にも理由をテキストで提示する)
+//   (widget が「未解決」表示に戻るだけだと「なぜ再度認証が必要なのか」が
+//    伝わらないため、widget 直下にも理由をテキストで提示する)
 // 文言を分けることでユーザーが原因を把握しやすくする。
 type TurnstileErrorState = null | "error" | "expire" | "submit_failed";
 
@@ -113,9 +113,9 @@ const CommentForm = ({ onSubmit, onCancel, disabled = false }: Props) => {
       // 投稿失敗時の方針:
       // - 入力欄 (userName / comment) は保持 → ユーザーが内容を再入力せずに済む
       // - Turnstile token は破棄 + widget reset → token 再利用の事故を防ぐ
-      // - turnstileError = "submit_failed" → widget 直下に「再認証が必要」
-      //   メッセージを表示 (親の alert だけでは widget を再解決する理由が
-      //   伝わらないため)
+      // - turnstileError = "submit_failed" → widget 直下にメッセージ表示
+      //   (widget が「未解決」表示に戻るだけだと再認証が必要な理由が
+      //    伝わらないため、文言でも明示する)
       //
       // 理由: Cloudflare Turnstile の token は single-use で、backend の
       // siteverify が 1 度通った時点で消費される (再 verify は失敗する仕様)。
@@ -125,7 +125,7 @@ const CommentForm = ({ onSubmit, onCancel, disabled = false }: Props) => {
       // ネットワーク断のような「backend 到達せず token 未消費」のケースでは
       // widget 再解決が必要になるが、auto/managed テーマは概ね invisible で
       // 解決するので UX 損失は限定的、トレードオフとして受容する。
-      // 投稿失敗の通知 (alert 等) は親 (PostDetail) 側の責務。
+      // 失敗の通信ログ (console.error 等) は親 (PostDetail) 側の責務。
       setTurnstileToken(null);
       setTurnstileError("submit_failed");
       setResetSignal((prev) => prev + 1);

--- a/app/src/components/organisms/CommentForm.tsx
+++ b/app/src/components/organisms/CommentForm.tsx
@@ -6,12 +6,40 @@ import CommentButtons from "@/components/molecules/CommentButtons";
 import TurnstileWidget from "@/components/molecules/TurnstileWidget";
 
 // Cloudflare Turnstile の Site Key。
-// dev / test では Cloudflare 公開のテストキー (always pass) をデフォルトに
-// フォールバックする。本番ビルドは Drone CI が --build-arg VITE_TURNSTILE_SITE_KEY
-// で本物の Site Key を埋め込む (app/Dockerfile.prod 参照)。
+// dev / test 環境では Cloudflare 公開のテストキー (always pass) にフォールバック
+// する。本番ビルドは Drone CI が --build-arg VITE_TURNSTILE_SITE_KEY で
+// 本物の Site Key を埋め込む (app/Dockerfile.prod 参照)。
+//
+// 本番では未設定 / 空文字を fail-fast で弾く:
+// - 公開テストキーへのフォールバックが Turnstile を実質無効化する事故を防ぐ
+// - 設定漏れをデプロイ直後 (モジュールロード時) に検知できる
+// - Dockerfile.prod 側でも build 時に required チェック済みだが二重ガード
+//
+// 評価順:
+// - 値が設定されていればそれを使う
+// - 未設定または空文字なら、本番では空のまま (下の if で throw)、dev/test は
+//   公開テストキー (1x00000000000000000000AA, always pass) にフォールバック
 // https://developers.cloudflare.com/turnstile/troubleshooting/testing/
 const TURNSTILE_SITE_KEY =
-  import.meta.env.VITE_TURNSTILE_SITE_KEY ?? "1x00000000000000000000AA";
+  import.meta.env.VITE_TURNSTILE_SITE_KEY ||
+  (import.meta.env.PROD ? "" : "1x00000000000000000000AA");
+
+if (!TURNSTILE_SITE_KEY) {
+  throw new Error("VITE_TURNSTILE_SITE_KEY is required in production");
+}
+
+// turnstileError state の取り得る値:
+// - null: エラー無し
+// - "error": widget のロード失敗 / script ブロック / network 断 等
+// - "expire": token の有効期限切れ (Cloudflare が再 challenge を促す状態)
+// 文言を分けることでユーザーが原因を把握しやすくする。
+type TurnstileErrorState = null | "error" | "expire";
+
+const TURNSTILE_ERROR_MESSAGES: Record<Exclude<TurnstileErrorState, null>, string> = {
+  error:
+    "認証 widget の読み込みに失敗しました。ネットワーク状況を確認し、ページを再読み込みしてください。",
+  expire: "認証の有効期限が切れました。widget を再度お試しください。",
+};
 
 type Props = {
   onSubmit: (
@@ -32,28 +60,29 @@ const CommentForm = ({ onSubmit, onCancel, disabled = false }: Props) => {
   const [resetSignal, setResetSignal] = useState(0);
   // widget のエラー / 期限切れ状態。ユーザーへフィードバックを表示するために使う
   // (token を null にするだけだとボタンが急に disabled になる理由が伝わらない)。
-  const [turnstileError, setTurnstileError] = useState(false);
+  const [turnstileError, setTurnstileError] =
+    useState<TurnstileErrorState>(null);
 
   const userNameId = useId();
   const commentId = useId();
 
   const handleTurnstileSuccess = useCallback((token: string) => {
     setTurnstileToken(token);
-    setTurnstileError(false);
+    setTurnstileError(null);
   }, []);
 
   const handleTurnstileExpire = useCallback(() => {
-    // token の有効期限切れ。submit を再度ブロックするため state をクリアする。
-    // ユーザーには再 challenge が必要であることをメッセージで伝える。
+    // token の有効期限切れ。submit を再度ブロックするため state をクリアし、
+    // ユーザーには有効期限切れの旨を expire 用メッセージで伝える。
     setTurnstileToken(null);
-    setTurnstileError(true);
+    setTurnstileError("expire");
   }, []);
 
   const handleTurnstileError = useCallback(() => {
-    // widget 側のエラー (ネットワーク断 / script load 失敗など)。
-    // token を無効化し、ユーザー向けにエラーメッセージを出す。
+    // widget 側のエラー (ネットワーク断 / script load 失敗 / 描画例外など)。
+    // token を無効化し、ユーザー向けにロード失敗メッセージを出す。
     setTurnstileToken(null);
-    setTurnstileError(true);
+    setTurnstileError("error");
   }, []);
 
   const handleSubmit = () => {
@@ -106,7 +135,7 @@ const CommentForm = ({ onSubmit, onCancel, disabled = false }: Props) => {
           role="alert"
           className="text-sm text-red-600 dark:text-red-400"
         >
-          認証 widget の読み込みに失敗しました。ネットワーク状況を確認し、ページを再読み込みしてください。
+          {TURNSTILE_ERROR_MESSAGES[turnstileError]}
         </p>
       )}
       <CommentButtons

--- a/app/src/components/organisms/CommentForm.tsx
+++ b/app/src/components/organisms/CommentForm.tsx
@@ -30,22 +30,30 @@ const CommentForm = ({ onSubmit, onCancel, disabled = false }: Props) => {
   const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
   // submit 成功後に widget を reset するためのカウンタ。
   const [resetSignal, setResetSignal] = useState(0);
+  // widget のエラー / 期限切れ状態。ユーザーへフィードバックを表示するために使う
+  // (token を null にするだけだとボタンが急に disabled になる理由が伝わらない)。
+  const [turnstileError, setTurnstileError] = useState(false);
 
   const userNameId = useId();
   const commentId = useId();
 
   const handleTurnstileSuccess = useCallback((token: string) => {
     setTurnstileToken(token);
+    setTurnstileError(false);
   }, []);
 
   const handleTurnstileExpire = useCallback(() => {
     // token の有効期限切れ。submit を再度ブロックするため state をクリアする。
+    // ユーザーには再 challenge が必要であることをメッセージで伝える。
     setTurnstileToken(null);
+    setTurnstileError(true);
   }, []);
 
   const handleTurnstileError = useCallback(() => {
-    // widget 側のエラー (ネットワーク断など)。token を無効化して再 challenge 待ち。
+    // widget 側のエラー (ネットワーク断 / script load 失敗など)。
+    // token を無効化し、ユーザー向けにエラーメッセージを出す。
     setTurnstileToken(null);
+    setTurnstileError(true);
   }, []);
 
   const handleSubmit = () => {
@@ -93,6 +101,14 @@ const CommentForm = ({ onSubmit, onCancel, disabled = false }: Props) => {
         onError={handleTurnstileError}
         resetSignal={resetSignal}
       />
+      {turnstileError && (
+        <p
+          role="alert"
+          className="text-sm text-red-600 dark:text-red-400"
+        >
+          認証 widget の読み込みに失敗しました。ネットワーク状況を確認し、ページを再読み込みしてください。
+        </p>
+      )}
       <CommentButtons
         onSubmit={handleSubmit}
         onCancel={onCancel}

--- a/app/src/components/organisms/__tests__/CommentForm.test.tsx
+++ b/app/src/components/organisms/__tests__/CommentForm.test.tsx
@@ -133,6 +133,33 @@ describe("CommentForm", () => {
     await waitFor(() => expect(submit).toBeDisabled());
   });
 
+  it("onSubmit が失敗 (reject) した場合は入力欄と token を保持して再投稿可能なこと", async () => {
+    const onSubmit = vi.fn().mockRejectedValue(new Error("network failure"));
+    const user = userEvent.setup();
+
+    render(<CommentForm onSubmit={onSubmit} onCancel={() => {}} />);
+
+    const nameInput = screen.getByPlaceholderText("ユーザ名");
+    const commentInput = screen.getByPlaceholderText("コメントを入力");
+
+    await user.type(nameInput, "alice");
+    await user.type(commentInput, "retry-needed");
+    act(() => {
+      mock.triggerSuccess("token-retry");
+    });
+
+    const submit = screen.getByRole("button", { name: "コメントを確定する" });
+    await waitFor(() => expect(submit).not.toBeDisabled());
+    await user.click(submit);
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+
+    // 失敗時は入力欄と token がクリアされず、ユーザーが再投稿できる状態が保たれる
+    expect(nameInput).toHaveValue("alice");
+    expect(commentInput).toHaveValue("retry-needed");
+    expect(submit).not.toBeDisabled();
+  });
+
   it("送信成功後に入力欄がクリアされること", async () => {
     const onSubmit = vi.fn();
     const user = userEvent.setup();

--- a/app/src/components/organisms/__tests__/CommentForm.test.tsx
+++ b/app/src/components/organisms/__tests__/CommentForm.test.tsx
@@ -140,7 +140,7 @@ describe("CommentForm", () => {
     await waitFor(() => expect(submit).toBeDisabled());
   });
 
-  it("onSubmit が失敗 (reject) した場合は入力欄を保持しつつ token を破棄して widget を reset すること", async () => {
+  it("onSubmit が失敗 (reject) した場合は入力欄を保持しつつ token を破棄して widget を reset し、再認証メッセージを表示すること", async () => {
     const onSubmit = vi.fn().mockRejectedValue(new Error("network failure"));
     const user = userEvent.setup();
 
@@ -172,6 +172,14 @@ describe("CommentForm", () => {
     await waitFor(() => {
       expect(mock.reset).toHaveBeenCalledWith("widget-id-stub");
     });
+    // ユーザーに「再認証が必要」な旨を widget 直下に表示する
+    // (error / expire と文言を分けることで原因を識別可能にする)。
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("投稿が失敗しました");
+    expect(alert).toHaveTextContent("認証 widget を再度解いて");
+    // error / expire 用文言と混ざらないことの担保
+    expect(alert).not.toHaveTextContent("ネットワーク状況を確認");
+    expect(alert).not.toHaveTextContent("有効期限が切れました");
   });
 
   it("失敗後に新しい token を取得すれば再投稿できること", async () => {
@@ -198,10 +206,18 @@ describe("CommentForm", () => {
     await user.click(submit);
 
     await waitFor(() => expect(submit).toBeDisabled());
+    // 失敗直後は再認証メッセージが表示される
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "投稿が失敗しました",
+    );
 
     // 2 回目: 新しい token B を取得 → submit → 成功
     act(() => {
       mock.triggerSuccess("token-B");
+    });
+    // 新 token を受け取った時点で「再認証が必要」メッセージは消える
+    await waitFor(() => {
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
     });
     await waitFor(() => expect(submit).not.toBeDisabled());
     await user.click(submit);

--- a/app/src/components/organisms/__tests__/CommentForm.test.tsx
+++ b/app/src/components/organisms/__tests__/CommentForm.test.tsx
@@ -1,0 +1,178 @@
+// app/src/components/organisms/__tests__/CommentForm.test.tsx
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, cleanup, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CommentForm from "../CommentForm";
+
+// CommentForm は TurnstileWidget を内部で描画するため、TurnstileWidget が依存する
+// window.turnstile (Cloudflare 公式 script が生やすグローバル) をモックする。
+// 実 script を読み込まないので、jsdom 環境で render / token 取得を再現する。
+const installTurnstileMock = () => {
+  const callbacks: {
+    success: ((token: string) => void) | null;
+    expire: (() => void) | null;
+  } = {
+    success: null,
+    expire: null,
+  };
+
+  (window as { turnstile?: unknown }).turnstile = {
+    render: vi.fn(
+      (
+        _el: HTMLElement,
+        options: {
+          callback?: (token: string) => void;
+          "expired-callback"?: () => void;
+        },
+      ) => {
+        callbacks.success = options.callback ?? null;
+        callbacks.expire = options["expired-callback"] ?? null;
+        return "widget-id-stub";
+      },
+    ),
+    remove: vi.fn(),
+    reset: vi.fn(),
+  };
+
+  return {
+    triggerSuccess: (token: string) => callbacks.success?.(token),
+    triggerExpire: () => callbacks.expire?.(),
+  };
+};
+
+describe("CommentForm", () => {
+  let mock: ReturnType<typeof installTurnstileMock>;
+
+  beforeEach(() => {
+    mock = installTurnstileMock();
+  });
+
+  afterEach(() => {
+    cleanup();
+    delete (window as { turnstile?: unknown }).turnstile;
+  });
+
+  it("Turnstile 未完了の状態では送信ボタンが disabled になっていること", async () => {
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+
+    render(<CommentForm onSubmit={onSubmit} onCancel={() => {}} />);
+
+    await user.type(screen.getByPlaceholderText("ユーザ名"), "alice");
+    await user.type(
+      screen.getByPlaceholderText("コメントを入力"),
+      "test content",
+    );
+
+    // 入力は揃っているが Turnstile 未完了なので submit は無効
+    const submit = screen.getByRole("button", { name: "コメントを確定する" });
+    expect(submit).toBeDisabled();
+
+    await user.click(submit);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("Turnstile token を受領後に送信できること, callback に token が渡ること", async () => {
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+
+    render(<CommentForm onSubmit={onSubmit} onCancel={() => {}} />);
+
+    await user.type(screen.getByPlaceholderText("ユーザ名"), "alice");
+    await user.type(
+      screen.getByPlaceholderText("コメントを入力"),
+      "hello world",
+    );
+
+    // Cloudflare Turnstile からの token 受領を模擬
+    act(() => {
+      mock.triggerSuccess("turnstile-token-xyz");
+    });
+
+    const submit = screen.getByRole("button", { name: "コメントを確定する" });
+    await waitFor(() => expect(submit).not.toBeDisabled());
+
+    await user.click(submit);
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith(
+      "alice",
+      "hello world",
+      "turnstile-token-xyz",
+    );
+  });
+
+  it("token の有効期限切れで送信ボタンが再度 disabled になること", async () => {
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+
+    render(<CommentForm onSubmit={onSubmit} onCancel={() => {}} />);
+
+    await user.type(screen.getByPlaceholderText("ユーザ名"), "alice");
+    await user.type(
+      screen.getByPlaceholderText("コメントを入力"),
+      "hello world",
+    );
+
+    // 一度 token を取得
+    act(() => {
+      mock.triggerSuccess("turnstile-token-xyz");
+    });
+    const submit = screen.getByRole("button", { name: "コメントを確定する" });
+    await waitFor(() => expect(submit).not.toBeDisabled());
+
+    // expired callback を模擬
+    act(() => {
+      mock.triggerExpire();
+    });
+    await waitFor(() => expect(submit).toBeDisabled());
+  });
+
+  it("送信成功後に入力欄がクリアされること", async () => {
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+
+    render(<CommentForm onSubmit={onSubmit} onCancel={() => {}} />);
+
+    const nameInput = screen.getByPlaceholderText("ユーザ名");
+    const commentInput = screen.getByPlaceholderText("コメントを入力");
+
+    await user.type(nameInput, "alice");
+    await user.type(commentInput, "first comment");
+    act(() => {
+      mock.triggerSuccess("turnstile-token-first");
+    });
+
+    const submit = screen.getByRole("button", { name: "コメントを確定する" });
+    await waitFor(() => expect(submit).not.toBeDisabled());
+    await user.click(submit);
+
+    // 入力欄がクリアされ、token も無効化されるので submit は再度 disabled
+    expect(nameInput).toHaveValue("");
+    expect(commentInput).toHaveValue("");
+    await waitFor(() => expect(submit).toBeDisabled());
+  });
+
+  it("disabled prop が true の時はあらゆる入力後も送信できないこと", async () => {
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <CommentForm onSubmit={onSubmit} onCancel={() => {}} disabled={true} />,
+    );
+
+    await user.type(screen.getByPlaceholderText("ユーザ名"), "alice");
+    await user.type(
+      screen.getByPlaceholderText("コメントを入力"),
+      "hello",
+    );
+    act(() => {
+      mock.triggerSuccess("turnstile-token-xyz");
+    });
+
+    const submit = screen.getByRole("button", { name: "コメントを確定する" });
+    expect(submit).toBeDisabled();
+    await user.click(submit);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/components/organisms/__tests__/CommentForm.test.tsx
+++ b/app/src/components/organisms/__tests__/CommentForm.test.tsx
@@ -158,7 +158,7 @@ describe("CommentForm", () => {
     await waitFor(() => expect(submit).toBeDisabled());
   });
 
-  it("Turnstile error 発生時にユーザー向けエラーメッセージが表示されること", async () => {
+  it("Turnstile error 発生時に「読み込みに失敗」メッセージが表示されること", async () => {
     render(<CommentForm onSubmit={() => {}} onCancel={() => {}} />);
 
     // 初期状態ではメッセージは出ていない
@@ -169,10 +169,12 @@ describe("CommentForm", () => {
     });
 
     const alert = await screen.findByRole("alert");
-    expect(alert).toHaveTextContent("認証 widget の読み込みに失敗しました");
+    expect(alert).toHaveTextContent(
+      "認証 widget の読み込みに失敗しました",
+    );
   });
 
-  it("Turnstile expire 発生時もエラーメッセージが表示されること", async () => {
+  it("Turnstile expire 発生時には別の「有効期限切れ」メッセージが表示されること", async () => {
     render(<CommentForm onSubmit={() => {}} onCancel={() => {}} />);
 
     act(() => {
@@ -180,7 +182,11 @@ describe("CommentForm", () => {
     });
 
     const alert = await screen.findByRole("alert");
-    expect(alert).toHaveTextContent("認証 widget の読み込みに失敗しました");
+    // expire はネットワーク障害ではないので、文言を別にして
+    // ユーザーが原因を取り違えないようにする
+    expect(alert).toHaveTextContent("認証の有効期限が切れました");
+    // error 用文言は混ざらない
+    expect(alert).not.toHaveTextContent("ネットワーク状況を確認");
   });
 
   it("エラーメッセージは新しい token 取得で消えること", async () => {

--- a/app/src/components/organisms/__tests__/CommentForm.test.tsx
+++ b/app/src/components/organisms/__tests__/CommentForm.test.tsx
@@ -18,27 +18,34 @@ const installTurnstileMock = () => {
     error: null,
   };
 
-  (window as { turnstile?: unknown }).turnstile = {
-    render: vi.fn(
-      (
-        _el: HTMLElement,
-        options: {
-          callback?: (token: string) => void;
-          "expired-callback"?: () => void;
-          "error-callback"?: () => void;
-        },
-      ) => {
-        callbacks.success = options.callback ?? null;
-        callbacks.expire = options["expired-callback"] ?? null;
-        callbacks.error = options["error-callback"] ?? null;
-        return "widget-id-stub";
+  const renderFn = vi.fn(
+    (
+      _el: HTMLElement,
+      options: {
+        callback?: (token: string) => void;
+        "expired-callback"?: () => void;
+        "error-callback"?: () => void;
       },
-    ),
-    remove: vi.fn(),
-    reset: vi.fn(),
+    ) => {
+      callbacks.success = options.callback ?? null;
+      callbacks.expire = options["expired-callback"] ?? null;
+      callbacks.error = options["error-callback"] ?? null;
+      return "widget-id-stub";
+    },
+  );
+  const removeFn = vi.fn();
+  const resetFn = vi.fn();
+
+  (window as { turnstile?: unknown }).turnstile = {
+    render: renderFn,
+    remove: removeFn,
+    reset: resetFn,
   };
 
   return {
+    render: renderFn,
+    remove: removeFn,
+    reset: resetFn,
     triggerSuccess: (token: string) => callbacks.success?.(token),
     triggerExpire: () => callbacks.expire?.(),
     triggerError: () => callbacks.error?.(),
@@ -133,7 +140,7 @@ describe("CommentForm", () => {
     await waitFor(() => expect(submit).toBeDisabled());
   });
 
-  it("onSubmit が失敗 (reject) した場合は入力欄と token を保持して再投稿可能なこと", async () => {
+  it("onSubmit が失敗 (reject) した場合は入力欄を保持しつつ token を破棄して widget を reset すること", async () => {
     const onSubmit = vi.fn().mockRejectedValue(new Error("network failure"));
     const user = userEvent.setup();
 
@@ -154,10 +161,54 @@ describe("CommentForm", () => {
 
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
 
-    // 失敗時は入力欄と token がクリアされず、ユーザーが再投稿できる状態が保たれる
+    // Cloudflare Turnstile の token は single-use なので、失敗時は token を
+    // 破棄 + widget reset して新しい token を取得しなおす設計。
+    // 入力欄はユーザーの再入力を不要にするため保持する。
     expect(nameInput).toHaveValue("alice");
     expect(commentInput).toHaveValue("retry-needed");
-    expect(submit).not.toBeDisabled();
+    // token を捨てたので submit は再 disabled。
+    expect(submit).toBeDisabled();
+    // widget を reset して新 challenge を求めることを確認。
+    await waitFor(() => {
+      expect(mock.reset).toHaveBeenCalledWith("widget-id-stub");
+    });
+  });
+
+  it("失敗後に新しい token を取得すれば再投稿できること", async () => {
+    const onSubmit = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("first try fails"))
+      .mockResolvedValueOnce(undefined);
+    const user = userEvent.setup();
+
+    render(<CommentForm onSubmit={onSubmit} onCancel={() => {}} />);
+
+    const nameInput = screen.getByPlaceholderText("ユーザ名");
+    const commentInput = screen.getByPlaceholderText("コメントを入力");
+
+    await user.type(nameInput, "alice");
+    await user.type(commentInput, "retry-needed");
+
+    // 1 回目: token A で submit → 失敗
+    act(() => {
+      mock.triggerSuccess("token-A");
+    });
+    const submit = screen.getByRole("button", { name: "コメントを確定する" });
+    await waitFor(() => expect(submit).not.toBeDisabled());
+    await user.click(submit);
+
+    await waitFor(() => expect(submit).toBeDisabled());
+
+    // 2 回目: 新しい token B を取得 → submit → 成功
+    act(() => {
+      mock.triggerSuccess("token-B");
+    });
+    await waitFor(() => expect(submit).not.toBeDisabled());
+    await user.click(submit);
+
+    expect(onSubmit).toHaveBeenCalledTimes(2);
+    // 2 回目の call は新 token (再利用していない) であることを確認
+    expect(onSubmit).toHaveBeenNthCalledWith(2, "alice", "retry-needed", "token-B");
   });
 
   it("送信成功後に入力欄がクリアされること", async () => {

--- a/app/src/components/organisms/__tests__/CommentForm.test.tsx
+++ b/app/src/components/organisms/__tests__/CommentForm.test.tsx
@@ -1,6 +1,13 @@
 // app/src/components/organisms/__tests__/CommentForm.test.tsx
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { render, screen, cleanup, waitFor, act } from "@testing-library/react";
+import {
+  render,
+  screen,
+  cleanup,
+  waitFor,
+  act,
+  fireEvent,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import CommentForm from "../CommentForm";
 
@@ -343,6 +350,57 @@ describe("CommentForm", () => {
     expect(submit).toBeDisabled();
 
     // 解決させて成功パスを完了させる
+    await act(async () => {
+      resolveOnSubmit?.();
+    });
+  });
+
+  // 同一 tick 内での同期的な再入を厳密に再現するテスト。
+  // userEvent.click は内部で React の render 完了を待つため、その直列利用だと
+  // 1 回目クリック後の isSubmitting state 反映で 2 回目以降は disabled な
+  // ボタンへの click として扱われる (DOM レベルでブロック)。
+  // fireEvent.click を同一 act 内で連続発火することで render 介入を挟まず、
+  // isSubmittingRef による「同期的な再入ガード」自体を直接テストできる。
+  it("同一 tick 内での連打でも isSubmittingRef により onSubmit が 1 回だけ呼ばれること", async () => {
+    let resolveOnSubmit: ((value: void) => void) | undefined;
+    const onSubmit = vi.fn().mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveOnSubmit = resolve;
+        }),
+    );
+    const user = userEvent.setup();
+
+    render(<CommentForm onSubmit={onSubmit} onCancel={() => {}} />);
+
+    await user.type(screen.getByPlaceholderText("ユーザ名"), "alice");
+    await user.type(
+      screen.getByPlaceholderText("コメントを入力"),
+      "sync-tick guard",
+    );
+    act(() => {
+      mock.triggerSuccess("token-sync");
+    });
+
+    const submit = screen.getByRole("button", { name: "コメントを確定する" });
+    await waitFor(() => expect(submit).not.toBeDisabled());
+
+    // 同一 act 内で fireEvent.click を 3 連発する = 同一 tick 内の同期的な
+    // 再入を再現する。userEvent.click と違い render 待ちを挟まないため、
+    // setIsSubmitting(true) の state 反映に依らない ref ガードを検証できる。
+    act(() => {
+      fireEvent.click(submit);
+      fireEvent.click(submit);
+      fireEvent.click(submit);
+    });
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith(
+      "alice",
+      "sync-tick guard",
+      "token-sync",
+    );
+
     await act(async () => {
       resolveOnSubmit?.();
     });

--- a/app/src/components/organisms/__tests__/CommentForm.test.tsx
+++ b/app/src/components/organisms/__tests__/CommentForm.test.tsx
@@ -300,6 +300,54 @@ describe("CommentForm", () => {
     });
   });
 
+  it("送信中の連打で onSubmit が複数回呼ばれないこと (二重送信防止 / 同じ token を再利用しない)", async () => {
+    // onSubmit を「resolve を外部から制御できる遅延 Promise」にして
+    // 「await 中に再クリックされた場合」をシミュレートする。
+    let resolveOnSubmit: ((value: void) => void) | undefined;
+    const onSubmit = vi.fn().mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveOnSubmit = resolve;
+        }),
+    );
+    const user = userEvent.setup();
+
+    render(<CommentForm onSubmit={onSubmit} onCancel={() => {}} />);
+
+    await user.type(screen.getByPlaceholderText("ユーザ名"), "alice");
+    await user.type(
+      screen.getByPlaceholderText("コメントを入力"),
+      "double-click guard",
+    );
+    act(() => {
+      mock.triggerSuccess("token-once");
+    });
+
+    const submit = screen.getByRole("button", { name: "コメントを確定する" });
+    await waitFor(() => expect(submit).not.toBeDisabled());
+
+    // 1 回目クリック (await 状態に入る) と 2 回目クリック (連打) をする。
+    // 2 回目は isSubmittingRef または isSubmitting でブロックされるべき。
+    await user.click(submit);
+    await user.click(submit);
+    await user.click(submit);
+
+    // 連打しても onSubmit は 1 回だけ呼ばれる = token 再利用されない
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith(
+      "alice",
+      "double-click guard",
+      "token-once",
+    );
+    // 送信中なので submit ボタンは disabled (視覚的にもガード)
+    expect(submit).toBeDisabled();
+
+    // 解決させて成功パスを完了させる
+    await act(async () => {
+      resolveOnSubmit?.();
+    });
+  });
+
   it("disabled prop が true の時はあらゆる入力後も送信できないこと", async () => {
     const onSubmit = vi.fn();
     const user = userEvent.setup();

--- a/app/src/components/organisms/__tests__/CommentForm.test.tsx
+++ b/app/src/components/organisms/__tests__/CommentForm.test.tsx
@@ -11,9 +11,11 @@ const installTurnstileMock = () => {
   const callbacks: {
     success: ((token: string) => void) | null;
     expire: (() => void) | null;
+    error: (() => void) | null;
   } = {
     success: null,
     expire: null,
+    error: null,
   };
 
   (window as { turnstile?: unknown }).turnstile = {
@@ -23,10 +25,12 @@ const installTurnstileMock = () => {
         options: {
           callback?: (token: string) => void;
           "expired-callback"?: () => void;
+          "error-callback"?: () => void;
         },
       ) => {
         callbacks.success = options.callback ?? null;
         callbacks.expire = options["expired-callback"] ?? null;
+        callbacks.error = options["error-callback"] ?? null;
         return "widget-id-stub";
       },
     ),
@@ -37,6 +41,7 @@ const installTurnstileMock = () => {
   return {
     triggerSuccess: (token: string) => callbacks.success?.(token),
     triggerExpire: () => callbacks.expire?.(),
+    triggerError: () => callbacks.error?.(),
   };
 };
 
@@ -151,6 +156,48 @@ describe("CommentForm", () => {
     expect(nameInput).toHaveValue("");
     expect(commentInput).toHaveValue("");
     await waitFor(() => expect(submit).toBeDisabled());
+  });
+
+  it("Turnstile error 発生時にユーザー向けエラーメッセージが表示されること", async () => {
+    render(<CommentForm onSubmit={() => {}} onCancel={() => {}} />);
+
+    // 初期状態ではメッセージは出ていない
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+
+    act(() => {
+      mock.triggerError();
+    });
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("認証 widget の読み込みに失敗しました");
+  });
+
+  it("Turnstile expire 発生時もエラーメッセージが表示されること", async () => {
+    render(<CommentForm onSubmit={() => {}} onCancel={() => {}} />);
+
+    act(() => {
+      mock.triggerExpire();
+    });
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("認証 widget の読み込みに失敗しました");
+  });
+
+  it("エラーメッセージは新しい token 取得で消えること", async () => {
+    render(<CommentForm onSubmit={() => {}} onCancel={() => {}} />);
+
+    act(() => {
+      mock.triggerError();
+    });
+    await screen.findByRole("alert");
+
+    act(() => {
+      mock.triggerSuccess("recovered-token");
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
   });
 
   it("disabled prop が true の時はあらゆる入力後も送信できないこと", async () => {

--- a/app/src/mocks/handlers.ts
+++ b/app/src/mocks/handlers.ts
@@ -258,18 +258,21 @@ export const handlers = [
   }),
 
   // コメント投稿
+  // 本物の backend は body の top-level に `turnstile_token` を要求するが、
+  // MSW (dev:mock) では検証を行わず素通しする。リクエスト body の shape は
+  // 本物に合わせて { comment: { user_name, comment }, turnstile_token } を受ける。
   http.post(`${API_BASE}/blogs/:id/comments`, async ({ params, request }) => {
     const blogId = parseInt(params.id as string, 10);
     const body = (await request.json()) as {
-      user_name: string;
-      comment: string;
+      comment: { user_name: string; comment: string };
+      turnstile_token?: string;
     };
 
     const newComment: Comment = {
       id: Date.now(),
       blog_id: blogId,
-      user_name: body.user_name,
-      comment: body.comment,
+      user_name: body.comment.user_name,
+      comment: body.comment.comment,
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
     };

--- a/app/src/pages/PostDetail.tsx
+++ b/app/src/pages/PostDetail.tsx
@@ -116,6 +116,9 @@ const PostDetail = () => {
     } catch (error) {
       console.error("コメント投稿エラー:", error);
       alert("コメントの投稿に失敗しました。もう一度お試しください。");
+      // CommentForm 側で入力欄を保持して再投稿可能にしてもらうため、
+      // エラーは飲み込まず再 throw する (CommentForm は catch して clear をスキップする)。
+      throw error;
     } finally {
       setIsSubmittingComment(false);
     }

--- a/app/src/pages/PostDetail.tsx
+++ b/app/src/pages/PostDetail.tsx
@@ -119,8 +119,8 @@ const PostDetail = () => {
       //   - userName / comment を保持 (ユーザーが再入力せずに済む)
       //   - turnstileToken を破棄 + widget reset (single-use の token 再利用回避)
       //   - turnstileError = "submit_failed" でユーザー向けメッセージ表示
-      // この 3 つで失敗の事実と次のアクションが十分伝わるため、alert() で
-      // モーダル通知して UX を中断する必要は無い (旧実装の alert() は撤去済み)。
+      // この 3 つで失敗の事実と次のアクションが十分伝わるので、ページ側で
+      // 追加のモーダル通知などは行わない (UX を中断しない方針)。
       throw error;
     } finally {
       setIsSubmittingComment(false);

--- a/app/src/pages/PostDetail.tsx
+++ b/app/src/pages/PostDetail.tsx
@@ -115,9 +115,12 @@ const PostDetail = () => {
       setIsWriting(false);
     } catch (error) {
       console.error("コメント投稿エラー:", error);
-      alert("コメントの投稿に失敗しました。もう一度お試しください。");
-      // CommentForm 側で入力欄を保持して再投稿可能にしてもらうため、
-      // エラーは飲み込まず再 throw する (CommentForm は catch して clear をスキップする)。
+      // CommentForm 側に失敗を伝播させる。CommentForm は catch で:
+      //   - userName / comment を保持 (ユーザーが再入力せずに済む)
+      //   - turnstileToken を破棄 + widget reset (single-use の token 再利用回避)
+      //   - turnstileError = "submit_failed" でユーザー向けメッセージ表示
+      // この 3 つで失敗の事実と次のアクションが十分伝わるため、alert() で
+      // モーダル通知して UX を中断する必要は無い (旧実装の alert() は撤去済み)。
       throw error;
     } finally {
       setIsSubmittingComment(false);

--- a/app/src/pages/PostDetail.tsx
+++ b/app/src/pages/PostDetail.tsx
@@ -75,7 +75,13 @@ const PostDetail = () => {
   }, [postId]);
 
   // コメント投稿処理
-  const handleCommentSubmit = async (name: string, content: string) => {
+  // turnstileToken は CommentForm 内の Turnstile widget が解決した token。
+  // body の top-level に `turnstile_token` として渡し、backend で siteverify される。
+  const handleCommentSubmit = async (
+    name: string,
+    content: string,
+    turnstileToken: string,
+  ) => {
     if (!postId) return;
 
     setIsSubmittingComment(true);
@@ -91,6 +97,7 @@ const PostDetail = () => {
             user_name: name.trim(),
             comment: content.trim(),
           },
+          turnstile_token: turnstileToken,
         }),
       });
 


### PR DESCRIPTION
## Summary

Phase 1C — backend で実装した Turnstile token 検証に対応する frontend 側。コメントフォームに Cloudflare Turnstile widget を描画し、submit 時に取得した token を POST body の top-level `turnstile_token` に乗せる。

これで Turnstile 一式 (ops Secret 注入 → backend 検証 → frontend widget) が揃い、bot による spam コメントを k8s 到達前に Cloudflare 層で弾けるようになる。

## 関連 PR (一連の Turnstile 導入)

| 段階 | repo | PR | 内容 | 状態 |
|---|---|---|---|---|
| Phase 1A | go-lilaregard-ops | [#242](https://github.com/terumitt-dev/go-lilaregard-ops/pull/242) | `TURNSTILE_SECRET_KEY` を `app-secrets` に注入 + `TURNSTILE_ALLOWED_HOSTNAMES` を ConfigMap に追加 | merged |
| Phase 1B | myblog-backend | [#73](https://github.com/terumitt-dev/myblog-backend/pull/73) | `TurnstileService` 新規 + `Api::CommentsController#create` に検証 before_action | merged |
| **Phase 1C** | **myblog-frontend** | **本 PR** | コメントフォームに widget 埋め込み + submit 時に token 同梱 | review 待ち |

backend は既に本番デプロイ済みで、現在は token なしの POST が 422 で弾かれている状態（curl 検証済み）。本 PR が merge されると frontend が token を取得して送るようになり、コメント機能が再び使えるようになる。

## 設計

### Widget の組み込み方

npm パッケージ追加 (`@marsidev/react-turnstile` 等) を避け、**Cloudflare 公式 script (`https://challenges.cloudflare.com/turnstile/v0/api.js`) を `index.html` から直接読み込み**、薄いラッパ `TurnstileWidget.tsx` (~90 行) を自作した。

- lookalike package による supply chain 攻撃 (近年の AI 関連 npm 攻撃も視野) のリスクをゼロにする
- 信頼の境界は Cloudflare 公式 endpoint のみ
- 実装も `window.turnstile.render / remove / reset` を呼ぶだけで boilerplate は少ない

### 主要ファイル

| ファイル | 内容 |
|---|---|
| `app/index.html` | Cloudflare 公式 script タグ追加 (`async defer`) |
| `app/src/components/molecules/TurnstileWidget.tsx` (新) | window.turnstile を呼ぶ薄いラッパ。token 取得 / expire / error / unmount cleanup / resetSignal で再 challenge |
| `app/src/components/organisms/CommentForm.tsx` | widget を埋め込み、token state を管理。token 未取得時は submit ボタン disabled |
| `app/src/pages/PostDetail.tsx` | `handleCommentSubmit` の signature を `(name, content, turnstileToken)` に拡張し、body に `turnstile_token` 追加 |
| `app/src/mocks/handlers.ts` | MSW handler を新 body shape 対応 (token は dev:mock では無視) |
| `app/Dockerfile.prod` | `ARG/ENV VITE_TURNSTILE_SITE_KEY` を追加 |
| `.drone.yml` | Drone org Secret `VITE_TURNSTILE_SITE_KEY` を `--build-arg` で Vite ビルドに注入 |

### Env / build 配線

- 本番: Drone CI が org Secret から Site Key を `--build-arg` で Vite ビルドに埋め込み
- dev / test: `import.meta.env.VITE_TURNSTILE_SITE_KEY ?? '1x00000000000000000000AA'` で Cloudflare 公開の always-pass テストキーにフォールバックするので、ローカル開発で追加設定不要

### UX

- token 未取得時: 「コメントを確定する」ボタン disabled
- token 取得: enabled
- submit 成功後: 入力欄クリア + widget 自動 reset で次回投稿時に新 token 要求
- token expire / error: token 無効化 → 再 disabled

## 動作仕様

| 状態 | 結果 |
|---|---|
| 入力欠落 (名前 or コメント空) | submit disabled |
| 入力 OK + Turnstile 未完了 | submit disabled |
| 入力 OK + token あり | submit 可能、body に `turnstile_token` 同梱 |
| token 期限切れ | submit 再び disabled、widget が再 challenge を要求 |

## Test plan

- [x] `vitest` フルスイート 85 examples / 0 failures (新規 11 ケース含む)
- [x] `tsc -b` clean
- [x] `eslint` clean
- [x] CI 通過 (Drone)
- [ ] merge 後 frontend Pod が `Running 1/1` で新 image に切り替わる
- [ ] ブラウザで `https://go-lilaregard.com` → 記事 → コメント入力 → widget 解いて「コメントを確定する」 → 投稿成功
- [ ] DevTools Network で POST body に `turnstile_token` が含まれ、レスポンスが 201 になる
- [ ] (任意) Turnstile widget を解かずに submit しても disabled で送信されない

## 前提作業

- Drone org Secret `VITE_TURNSTILE_SITE_KEY` が登録済みであること（backend `TURNSTILE_SECRET_KEY` 登録時に一緒に入れた前提）
- Cloudflare Turnstile site (`myblog-comments`) のドメインに `go-lilaregard.com` が含まれていること（既に運用中で確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)