### PR TITLE
chore: ルートに .gitignore を追加して .DS_Store を除外

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
## Summary
- リポジトリルートに `.gitignore` が存在しなかったため、macOS が生成する `.DS_Store` が untracked のまま残り続けていた
- ルートに `.gitignore` を追加して `.DS_Store` を除外

## 背景
`app/` 配下に `.gitignore` はあったが、ルートレベルのものが初期構成から存在しなかった。